### PR TITLE
fix: example server crash on insecure SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,15 +107,11 @@ My personal crate recommendation list:
 
 ## TLS certificate
 
-Some code examples are using TLS for authentication.
-
-To access HTTPS servers from your browser, you'll first need to import the
-certificate from this repository (Chrome/Firefox):
-
-1. Open browser settings and go to the certificate *Authorities* list.
-2. Click *Import* and select `certificate.pem`.
-3. Enable *Trust this CA to identify websites* and click *OK*.
-4. Restart the browser (yes, you have to!) and go to [https://127.0.0.1:8001](https://127.0.0.1:8001)
+Some code examples are using TLS for authentication. The repository
+contains a self-signed certificate usable for testing. It should *not*
+be used for real world scenarios. Browsers and tools like curl will
+show this certificate as insecure. In browsers, accept the security
+prompt or use `curl -k` on the command line to bypass security warnings.
 
 The certificate file was generated using
 [minica](https://github.com/jsha/minica) and

--- a/examples/async-h1-server.rs
+++ b/examples/async-h1-server.rs
@@ -55,8 +55,12 @@ async fn listen(listener: Async<TcpListener>, tls: Option<TlsAcceptor>) -> Resul
             }
             Some(tls) => {
                 // In case of HTTPS, establish a secure TLS connection first.
-                let stream = tls.accept(stream).await?;
-                let stream = Arc::new(Mutex::new(stream));
+                let stream = tls.accept(stream).await;
+                if let Err(e) = stream {
+                    println!("Failed to establish secure TLS connection: {:#?}", e);
+                    continue;
+                };
+                let stream = Arc::new(Mutex::new(stream.unwrap()));
                 Task::spawn(async move { async_h1::accept(&host, stream, serve).await })
             }
         };


### PR DESCRIPTION
Fixes the async-h1-server example in case of insecure SSL connection

before:
```bash
ace@ace-home-vm:~/code/smol/examples$ cargo run --example async-h1-server
   Compiling smol-examples v0.0.0 (/home/ace/code/smol/examples)
    Finished dev [unoptimized + debuginfo] target(s) in 2.53s
     Running `/home/ace/code/smol/target/debug/examples/async-h1-server`
Listening on http://127.0.0.1:8000
Listening on https://127.0.0.1:8001
Error: error:14094418:SSL routines:ssl3_read_bytes:tlsv1 alert unknown ca:../ssl/record/rec_layer_s3.c:1528:SSL alert number 48

Caused by:
    error:14094418:SSL routines:ssl3_read_bytes:tlsv1 alert unknown ca:../ssl/record/rec_layer_s3.c:1528:SSL alert number 48
ace@ace-home-vm:~/code/smol/examples$ 
```

after:
```
ace@ace-home-vm:~/code/smol/examples$ cargo run --example async-h1-server
   Compiling smol-examples v0.0.0 (/home/ace/code/smol/examples)
    Finished dev [unoptimized + debuginfo] target(s) in 2.69s
     Running `/home/ace/code/smol/target/debug/examples/async-h1-server`
Listening on http://127.0.0.1:8000
Listening on https://127.0.0.1:8001
Failed to establish secure TLS connection: Ssl(
    Error {
        code: ErrorCode(
            1,
        ),
        cause: Some(
            Ssl(
                ErrorStack(
                    [
                        Error {
                            code: 336151576,
                            library: "SSL routines",
                            function: "ssl3_read_bytes",
                            reason: "tlsv1 alert unknown ca",
                            file: "../ssl/record/rec_layer_s3.c",
                            line: 1528,
                            data: "SSL alert number 48",
                        },
                    ],
                ),
            ),
        ),
    },
    X509VerifyResult {
        code: 0,
        error: "ok",
    },
)
```