### PR TITLE
Report total lines of code in CI as a lint pass

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -63,4 +63,3 @@ jobs:
 
     - name: test
       run: cross test --target ${{ matrix.target }}
-

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,3 +16,15 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
+  loc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Install cargo-count
+        run: cargo install cargo-count
+
+      - name: Run cargo count
+        # '-a --exclude=$(cat .gitignore)' necessary to work around:
+        # https://github.com/kbknapp/cargo-count/issues/36
+        run: cargo count -l rs -a --exclude=$(cat .gitignore) src


### PR DESCRIPTION
I would like it if that count could also be posted as an automatic comment for better visibility but it doesnt look like that's possible.