### PR TITLE
Only run CI in either pull requests or master

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,6 +1,10 @@
 name: Build and test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build_and_test:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,10 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   clippy:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,6 +1,10 @@
 name: Security audit
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   security_audit:


### PR DESCRIPTION
This is useful because if you are a project collaborator and do
not fork to push changes to a new branch then CI will run for both
the pull request and the branch to which you're pushing your
changes, duplicating all jobs.

I think it's acceptable to disable CI for any other branch than
master and allow it if a branch has an associated pull request.

One can create a draft pull request to develop along with CI in
a local branch.