### PR TITLE
Ci code coverage

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,0 +1,8 @@
+branch: true
+ignore-not-existing: true
+llvm: true
+output-type: lcov
+ignore:
+  - "/*"
+  - "C:/*"
+  - "../*"

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -16,6 +16,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
             toolchain: ${{ matrix.rust }}
+            profile: minimal
             override: true
 
       - name: Run cargo check

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,62 @@
+name: Code Coverage
+
+on: [push, pull_request]
+
+jobs:
+  grcov:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Run cargo test
+        if: startsWith(matrix.os, 'macOS') == false
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all --all-features --no-fail-fast
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+
+      # The only difference from previous step is that `RUSTFLAGS` `-Clink-dead-code` flag
+      # is removed for macOS tests because `core-foundation` crate breaks compilation.
+      #
+      # See https://github.com/rust-lang/rust/issues/63047 for details
+      - name: Run cargo test (macOS)
+        if: startsWith(matrix.os, 'macOS') == true
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all --all-features --no-fail-fast
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Coverflow-checks=off'
+
+      - name: Run grcov
+        id: coverage
+        uses: actions-rs/grcov@v0.1
+      - name: Coveralls upload
+        uses: coverallsapp/github-action@v1.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ${{ steps.coverage.outputs.report }}
+
+  grcov_finalize:
+    runs-on: ubuntu-latest
+    needs: grcov
+    steps:
+      - name: Finalize Coveralls upload
+        uses: coverallsapp/github-action@v1.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: rustup component add clippy
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: clippy
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build](https://github.com/stjepang/smol/workflows/Build%20and%20test/badge.svg)](
 https://travis-ci.org/stjepang/smol)
+[![Coverage Status](https://coveralls.io/repos/github/stjepang/smol/badge.svg?branch=master)](
+https://coveralls.io/github/stjepang/smol?branch=master)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](
 https://github.com/stjepang/smol)
 [![Cargo](https://img.shields.io/crates/v/smol.svg)](


### PR DESCRIPTION
1. [grcov](https://github.com/mozilla/grcov) tool is used, since `smol` contains platform-specific code
2. Note that in order to make this work for all major OSes, `cargo test` is called differently for macOS; linked issue is caused by `core-foundation` -> `native-tls` dependency chain somewhere deeply in the deps tree
3. @stjepang, can you log into [Coveralls](coveralls.io) first and grant access to the `smol` repository first? It is required to show coverage results in there.
4. I also changed `rustup` profile to `minimal` for other CI workflows in order to make execution a bit faster in some cases