### PR TITLE
Use actions-rs/install Action to speed up CI execution

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -57,7 +57,10 @@ jobs:
         override: true
 
     - name: Install cross
-      run: cargo install cross
+      uses: actions-rs/install@v0.1
+      with:
+        crate: cross
+        use-tool-cache: true
 
     - name: check
       run: cross check --target ${{ matrix.target }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,6 +42,12 @@ jobs:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Coverflow-checks=off'
 
+      - name: Install grcov
+        uses: actions-rs/install@v0.1
+        with:
+          crate: grcov
+          use-tool-cache: true
+
       - name: Run grcov
         id: coverage
         uses: actions-rs/grcov@v0.1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,10 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: Install cargo-count
-        run: cargo install cargo-count
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-count
+          use-tool-cache: true
 
       - name: Run cargo count
         # '-a --exclude=$(cat .gitignore)' necessary to work around:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -11,6 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-audit
+          use-tool-cache: true
+
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It is possible to speed up CI a bit by using [actions-rs/install](https://github.com/actions-rs/install) Action, which speeds up binary crates installation (`grcov`, `cross` and `cargo-count` in `smol` case).

I feel obligated to point out that using this Action in a current state is potentially insecure, you can read more about it here: https://github.com/actions-rs/install/#tool-cache
It is the reason why this PR is in a draft state, so all maintainers can consider the situation first without accidentally merging it.

Also, note that `cargo-count` is not stored in the binary crates cache right now and this Action will fall back to usual `cargo install cargo-count` command, same as it was before in the workflow file.