### PR TITLE
Remove most no_run on doc tests

### DIFF
--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -44,7 +44,7 @@ use crate::task::Task;
 ///
 /// To make an async I/O handle cloneable, wrap it in [piper]'s `Arc`:
 ///
-/// ```no_run
+/// ```
 /// use piper::Arc;
 /// use smol::Async;
 /// use std::net::TcpStream;
@@ -65,7 +65,7 @@ use crate::task::Task;
 /// If a type does but its reference doesn't implement [`AsyncRead`] and [`AsyncWrite`], wrap it in
 /// [piper]'s `Mutex`:
 ///
-/// ```no_run
+/// ```
 /// use futures::prelude::*;
 /// use piper::{Arc, Mutex};
 /// use smol::Async;
@@ -129,7 +129,7 @@ impl<T: AsRawFd> Async<T> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::net::TcpListener;
     ///
@@ -185,7 +185,7 @@ impl<T: AsRawSocket> Async<T> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::net::TcpListener;
     ///
@@ -283,7 +283,7 @@ impl<T> Async<T> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::net::TcpListener;
     ///
@@ -313,7 +313,7 @@ impl<T> Async<T> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::net::TcpListener;
     ///
@@ -451,7 +451,7 @@ impl Async<TcpListener> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::net::TcpListener;
     ///
@@ -475,7 +475,7 @@ impl Async<TcpListener> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::net::TcpListener;
     ///
@@ -496,7 +496,7 @@ impl Async<TcpListener> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use futures::prelude::*;
     /// use smol::Async;
     /// use std::net::TcpListener;
@@ -524,7 +524,7 @@ impl Async<TcpStream> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::net::TcpStream;
     ///
@@ -573,7 +573,7 @@ impl Async<TcpStream> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::net::TcpStream;
     ///
@@ -596,7 +596,7 @@ impl Async<UdpSocket> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::net::UdpSocket;
     ///
@@ -667,7 +667,7 @@ impl Async<UdpSocket> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::net::UdpSocket;
     ///
@@ -750,7 +750,7 @@ impl Async<UdpSocket> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::net::UdpSocket;
     ///
@@ -773,7 +773,7 @@ impl Async<UnixListener> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::os::unix::net::UnixListener;
     ///
@@ -794,7 +794,7 @@ impl Async<UnixListener> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::os::unix::net::UnixListener;
     ///
@@ -815,7 +815,7 @@ impl Async<UnixListener> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use futures::prelude::*;
     /// use smol::Async;
     /// use std::os::unix::net::UnixListener;
@@ -846,7 +846,7 @@ impl Async<UnixStream> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::os::unix::net::UnixStream;
     ///
@@ -888,7 +888,7 @@ impl Async<UnixStream> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::os::unix::net::UnixStream;
     ///
@@ -908,7 +908,7 @@ impl Async<UnixDatagram> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///
@@ -925,7 +925,7 @@ impl Async<UnixDatagram> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///
@@ -941,7 +941,7 @@ impl Async<UnixDatagram> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///
@@ -960,7 +960,7 @@ impl Async<UnixDatagram> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///
@@ -981,7 +981,7 @@ impl Async<UnixDatagram> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///
@@ -1006,7 +1006,7 @@ impl Async<UnixDatagram> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///
@@ -1031,7 +1031,7 @@ impl Async<UnixDatagram> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Async;
     /// use std::os::unix::net::UnixDatagram;
     ///

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -167,7 +167,7 @@ impl BlockingExecutor {
 ///
 /// Read a file into a string:
 ///
-/// ```no_run
+/// ```
 /// use smol::blocking;
 /// use std::fs;
 ///
@@ -178,7 +178,7 @@ impl BlockingExecutor {
 ///
 /// Spawn a process:
 ///
-/// ```no_run
+/// ```
 /// use smol::blocking;
 /// use std::process::Command;
 ///
@@ -202,7 +202,7 @@ macro_rules! blocking {
 ///
 /// List files in the current directory:
 ///
-/// ```no_run
+/// ```
 /// use futures::stream::StreamExt;
 /// use smol::{blocking, iter};
 /// use std::fs;
@@ -291,7 +291,7 @@ pub fn iter<T: Send + 'static>(
 ///
 /// Read from a file:
 ///
-/// ```no_run
+/// ```
 /// use futures::prelude::*;
 /// use smol::{blocking, reader};
 /// use std::fs::File;
@@ -309,7 +309,7 @@ pub fn iter<T: Send + 'static>(
 ///
 /// Read output from a process:
 ///
-/// ```no_run
+/// ```
 /// use futures::prelude::*;
 /// use smol::reader;
 /// use std::process::{Command, Stdio};
@@ -402,7 +402,7 @@ pub fn reader(reader: impl Read + Send + 'static) -> impl AsyncRead + Send + Unp
 ///
 /// Write into a file:
 ///
-/// ```no_run
+/// ```
 /// use futures::prelude::*;
 /// use smol::{blocking, writer};
 /// use std::fs::File;
@@ -420,7 +420,7 @@ pub fn reader(reader: impl Read + Send + 'static) -> impl AsyncRead + Send + Unp
 ///
 /// Write into standard output:
 ///
-/// ```no_run
+/// ```
 /// use futures::prelude::*;
 /// use smol::writer;
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! Connect to a HTTP website, make a GET request, and pipe the response to the standard output:
 //!
-//! ```no_run
+//! ```
 //! use futures::prelude::*;
 //! use smol::Async;
 //! use std::net::TcpStream;

--- a/src/run.rs
+++ b/src/run.rs
@@ -34,7 +34,7 @@ use crate::work_stealing::WorkStealingExecutor;
 ///
 /// Multi-threaded executor:
 ///
-/// ```no_run
+/// ```
 /// use futures::future;
 /// use smol::Task;
 /// use std::thread;

--- a/src/task.rs
+++ b/src/task.rs
@@ -111,7 +111,7 @@ impl<T: Send + 'static> Task<T> {
     ///
     /// Read a line from the standard input:
     ///
-    /// ```no_run
+    /// ```
     /// use smol::Task;
     /// use std::io::stdin;
     ///
@@ -191,7 +191,7 @@ impl Task<()> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use smol::{Task, Timer};
     /// use std::time::Duration;
     ///


### PR DESCRIPTION
Looks like there are many doc tests are set as `no_run`. Remove these can increase lines of code coverage significantly.