### PR TITLE
Run code coverage CI on either master or pull request

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   grcov:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: Code Coverage
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   grcov:


### PR DESCRIPTION
I think code coverage workflow should only run on master.
Edit: Added pull request back.