### PR TITLE
Use a better representation for some errors

### DIFF
--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -464,7 +464,7 @@ impl Async<TcpListener> {
         let addr = addr
             .to_string()
             .parse::<SocketAddr>()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         Ok(Async::new(TcpListener::bind(addr)?)?)
     }
 
@@ -557,7 +557,7 @@ impl Async<TcpStream> {
         // Wait for connect to complete.
         let wait_connect = |mut stream: &TcpStream| match stream.write(&[]) {
             Err(err) if err.kind() == io::ErrorKind::NotConnected => {
-                Err(io::Error::new(io::ErrorKind::WouldBlock, ""))
+                Err(io::ErrorKind::WouldBlock.into())
             }
             res => res.map(|_| ()),
         };
@@ -609,7 +609,7 @@ impl Async<UdpSocket> {
         let addr = addr
             .to_string()
             .parse::<SocketAddr>()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         Ok(Async::new(UdpSocket::bind(addr)?)?)
     }
 
@@ -874,7 +874,7 @@ impl Async<UnixStream> {
         // Wait for connect to complete.
         let wait_connect = |mut stream: &UnixStream| match stream.write(&[]) {
             Err(err) if err.kind() == io::ErrorKind::NotConnected => {
-                Err(io::Error::new(io::ErrorKind::WouldBlock, ""))
+                Err(io::ErrorKind::WouldBlock.into())
             }
             res => res.map(|_| ()),
         };

--- a/src/io_event.rs
+++ b/src/io_event.rs
@@ -82,7 +82,7 @@ impl IoEvent {
                 if self.0.flag.load(Ordering::SeqCst) {
                     Ok(())
                 } else {
-                    Err(io::Error::new(io::ErrorKind::WouldBlock, ""))
+                    Err(io::ErrorKind::WouldBlock.into())
                 }
             })
             .await


### PR DESCRIPTION
This just takes the representations introduced in https://github.com/stjepang/smol/commit/45d668a22a2ce9bb40de168a93ed5b062c3cd44f and https://github.com/stjepang/smol/blob/6ae620ac3a38f72dcc0d38eb02dc39a048ec83ae/src/reactor.rs#L214
and reuses them for similar errors