### PR TITLE
Only consume budget on successful I/O operations

### DIFF
--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -343,7 +343,13 @@ impl Source {
             // Attempt the non-blocking operation.
             match op() {
                 Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-                res => return Poll::Ready(res),
+                res => {
+                    // Consume a unit of I/O budget.
+                    if res.is_ok() {
+                        throttle::bump();
+                    }
+                    return Poll::Ready(res);
+                }
             }
 
             // Lock the waker list and retry the non-blocking operation.


### PR DESCRIPTION
We don't want to throttle tasks that poll lots of pending I/O operations - we should only throttle them *if they make progress*.