### PR TITLE
 Enhance tcp socket conn error message.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ nix = "0.17.0"
 
 [target.'cfg(windows)'.dependencies]
 wepoll-binding = "2.0.0"
+libc = "0.2.69"
 
 [dev-dependencies]
 num_cpus = "1.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ nix = "0.17.0"
 
 [target.'cfg(windows)'.dependencies]
 wepoll-binding = "2.0.0"
-libc = "0.2.69"
 
 [dev-dependencies]
 num_cpus = "1.13.0"

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -26,6 +26,8 @@ use socket2::{Domain, Protocol, Socket, Type};
 
 use crate::reactor::{Reactor, Source};
 use crate::task::Task;
+
+#[cfg(unix)]
 use nix::libc;
 
 /// Async I/O.

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -553,7 +553,10 @@ impl Async<TcpStream> {
         // Begin async connect and ignore the inevitable "not yet connected" error.
         socket.set_nonblocking(true)?;
         socket.connect(&addr.into()).or_else(|err| {
-            if err.raw_os_error() == Some(libc::EINPROGRESS) {
+            //Ignore error EINPROGRESS on Unix or WSAEWOULDBLOCK on windows, as it means connection in progress.
+            if err.raw_os_error() == Some(libc::EINPROGRESS)
+                || err.kind() == io::ErrorKind::WouldBlock
+            {
                 Ok(())
             } else {
                 Err(err)


### PR DESCRIPTION
PR for : https://github.com/stjepang/smol/issues/60

 Ignore the `EINPROGRESS` connection error, while establishing Async Tcpstream socket connection.