### PR TITLE
Skip notifying the reactor for added timers unnecessarily

### DIFF
--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -150,8 +150,12 @@ impl Reactor {
             self.fire_timers();
         }
 
-        // Notify that a timer was added.
-        self.timer_event.notify();
+        if let Some(_reactor_lock) = self.try_lock() {
+            // Since we got the lock, no one else has it, so we don't need to wake up the reactor.
+        } else {
+            // Notify that a timer was added.
+            self.timer_event.notify();
+        }
 
         id
     }


### PR DESCRIPTION
When a timer is inserted into the reactor, a message is sent to the
timer_event object so that someone waiting in the reactor gets woken up
early so that they can consider if the new timer is will trigger before
they would have originally woken up.

However, if no one is waiting in the reactor, this step is unnecessary.
In a case with only one executor thread, this is always true, since
timers aren't added while the reactor lock is held. Furthermore, if you
notify the reactor while no one is holding the lock, the next reactor
wait will return immediately, which will make you go through the event
loop again unnecessarily.

Fixes #113