### PR TITLE
Refer to futures sub-crates explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ tokio02 = ["tokio"]
 async-task = "3.0.0"
 blocking = "0.3.2"
 crossbeam = "0.7.3"
-futures = { version = "0.3.4", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 once_cell = "1.3.1"
 piper = "0.1.1"
 scoped-tls-hkt = "0.1.2"
@@ -48,6 +49,7 @@ nix = "0.17.0"
 wepoll-binding = "2.0.0"
 
 [dev-dependencies]
+futures = { version = "0.3.5", default-features = false, features = ["std"] }
 num_cpus = "1.13.0"
 tempfile = "3.1.0"
 criterion = "0.3"

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -19,9 +19,9 @@ use std::{
     path::Path,
 };
 
-use futures::future;
-use futures::io::{AsyncRead, AsyncWrite};
-use futures::stream::{self, Stream};
+use futures_util::future;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::stream::{self, Stream};
 use socket2::{Domain, Protocol, Socket, Type};
 
 use crate::reactor::{Reactor, Source};
@@ -347,7 +347,7 @@ impl<T> Drop for Async<T> {
 
 /// Pins a future and then polls it.
 fn poll_future<T>(cx: &mut Context<'_>, fut: impl Future<Output = T>) -> Poll<T> {
-    futures::pin_mut!(fut);
+    futures_util::pin_mut!(fut);
     fut.poll(cx)
 }
 

--- a/src/block_on.rs
+++ b/src/block_on.rs
@@ -61,7 +61,7 @@ pub fn block_on<T>(future: impl Future<Output = T>) -> T {
 
         // If enabled, set up tokio before execution begins.
         context::enter(|| {
-            futures::pin_mut!(future);
+            futures_util::pin_mut!(future);
             let cx = &mut Context::from_waker(&waker);
 
             loop {

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -21,8 +21,8 @@
 
 use std::io::{Read, Write};
 
-use futures::io::{AsyncRead, AsyncWrite};
-use futures::stream::Stream;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::stream::Stream;
 
 /// Spawns blocking code onto a thread.
 ///

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -331,7 +331,7 @@ impl Source {
         mut op: impl FnMut() -> io::Result<R>,
     ) -> Poll<io::Result<R>> {
         // Throttle if the current task did too many I/O operations without yielding.
-        futures::ready!(throttle::poll(cx));
+        futures_util::ready!(throttle::poll(cx));
 
         loop {
             // This number is bumped just before I/O notifications while wakers are locked.

--- a/src/run.rs
+++ b/src/run.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use std::task::{Context, Poll};
 use std::thread;
 
-use futures::future::{self, Either};
+use futures_util::future::{self, Either};
 
 use crate::block_on;
 use crate::context;
@@ -105,7 +105,7 @@ pub fn run<T>(future: impl Future<Output = T>) -> T {
     let ev = local.event().clone();
     let waker = async_task::waker_fn(move || ev.notify());
     let cx = &mut Context::from_waker(&waker);
-    futures::pin_mut!(future);
+    futures_util::pin_mut!(future);
 
     // Set up tokio (if enabled) and the thread-locals before execution begins.
     let enter = context::enter;
@@ -184,8 +184,8 @@ pub fn run<T>(future: impl Future<Output = T>) -> T {
             // event whenever it finds a runnable task.
             let lock = reactor.lock();
             let notified = local.event().notified();
-            futures::pin_mut!(lock);
-            futures::pin_mut!(notified);
+            futures_util::pin_mut!(lock);
+            futures_util::pin_mut!(notified);
 
             // Block until either the reactor is locked or `local.event()` is triggered.
             if let Either::Left((reactor_lock, _)) = block_on(future::select(lock, notified)) {


### PR DESCRIPTION
When used against the latest versions of [`piper`](https://github.com/stjepang/piper/pull/21) and [`blocking`](https://github.com/stjepang/blocking/pull/2), the amount of dependencies on initial compile is reduced from 59 to 58.

Overall, not a massive win, but maybe there is more potential for `futures_util`, which seems to a mixed bag of plenty of functionality, bringing in nearly all the dependencies of `futures` itself.