### PR TITLE
Fix Task::blocking(…).detach()

### DIFF
--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -19,8 +19,8 @@ use std::{
     path::Path,
 };
 
-use futures_util::future;
 use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::future;
 use futures_util::stream::{self, Stream};
 use socket2::{Domain, Protocol, Socket, Type};
 

--- a/tests/task.rs
+++ b/tests/task.rs
@@ -1,0 +1,23 @@
+#[test]
+fn spawn() {
+    assert_eq!(42, smol::run(smol::Task::spawn(async { 42 })));
+}
+
+#[test]
+fn spawn_detach() {
+    let (s, r) = piper::chan(1);
+    smol::Task::spawn(async move { s.send(()).await }).detach();
+    assert_eq!(Some(()), smol::run(r.recv()));
+}
+
+#[test]
+fn blocking() {
+    assert_eq!(42, smol::run(smol::Task::blocking(async { 42 })));
+}
+
+#[test]
+fn blocking_detach() {
+    let (s, r) = piper::chan(1);
+    smol::Task::blocking(async move { s.send(()).await }).detach();
+    assert_eq!(Some(()), smol::run(r.recv()));
+}


### PR DESCRIPTION
As opposed to Task::spawn(…).detach(), blocking tasks don't complete
unless their receiving future is polled.

Previously the future would just be dropped, which caused the blocking
future not to be evaluated.

Now the future is spawned and detached to assure it gets completed
eventually and automatically.

Please note that this is my 'brute force' workaround that can also be applied manually by doing `smol::Task::spawn(smol::Task::blocking(…)).detach()`, but at least it fixes otherwise surprising and probably wrong beaviour.

The `task::blocking_detach(…)` test breaks unless the fix is applied.