### PR TITLE
Tests to prevent against recent regression of Task::blocking(…).detach()

### DIFF
--- a/tests/task.rs
+++ b/tests/task.rs
@@ -1,0 +1,23 @@
+#[test]
+fn spawn() {
+    assert_eq!(42, smol::run(smol::Task::spawn(async { 42 })));
+}
+
+#[test]
+fn spawn_detach() {
+    let (s, r) = piper::chan(1);
+    smol::Task::spawn(async move { s.send(()).await }).detach();
+    assert_eq!(Some(()), smol::run(r.recv()));
+}
+
+#[test]
+fn blocking() {
+    assert_eq!(42, smol::run(smol::Task::blocking(async { 42 })));
+}
+
+#[test]
+fn blocking_detach() {
+    let (s, r) = piper::chan(1);
+    smol::Task::blocking(async move { s.send(()).await }).detach();
+    assert_eq!(Some(()), smol::run(r.recv()));
+}


### PR DESCRIPTION
Related to #119 

Previously, the last of the 4 tests added in the PR was able to catch the regression that was fixed with v0.1.8. Do you think having a test for that would help? Or is this covered elsewhere now?