### PR TITLE
Split with() into read_with() and write_with()

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -50,6 +50,23 @@ jobs:
         with:
           command: test
 
+  cross:
+    name: Cross compile
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-apple-ios
+          - aarch64-linux-android
+          - aarch64-pc-windows-msvc
+          - x86_64-apple-darwin
+          - i686-unknown-linux-gnu
+          - powerpc64-unknown-linux-gnu
+          - powerpc64le-unknown-linux-gnu
+					- x86_64-unknown-freebsd
+          # - x86_64-unknown-illumos
+
     steps:
       - uses: actions/checkout@v2
 
@@ -67,6 +84,3 @@ jobs:
 
       - name: check
         run: cross check --target ${{ matrix.target }}
-
-      - name: test
-        run: cross test --target ${{ matrix.target }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -50,22 +50,6 @@ jobs:
         with:
           command: test
 
-  cross:
-    name: Cross compile
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - aarch64-apple-ios
-          - aarch64-linux-android
-          - aarch64-pc-windows-msvc
-          - i686-unknown-linux-gnu
-          - powerpc64-unknown-linux-gnu
-          - powerpc64le-unknown-linux-gnu
-          - x86_64-unknown-freebsd
-          # - x86_64-unknown-illumos
-
     steps:
     - uses: actions/checkout@v2
     

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -51,22 +51,22 @@ jobs:
           command: test
 
     steps:
-    - uses: actions/checkout@v2
-    
-    - name: Set current week of the year in environnement
-      run: echo "::set-env name=CURRENT_WEEK::$(date +%V)"
-    
-    - name: Install nightly
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
+      - uses: actions/checkout@v2
 
-    - name: Install cross
-      run: cargo install cross || true
+      - name: Set current week of the year in environnement
+        run: echo "::set-env name=CURRENT_WEEK::$(date +%V)"
 
-    - name: check
-      run: cross check --target ${{ matrix.target }}
+      - name: Install nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
 
-    - name: test
-      run: cross test --target ${{ matrix.target }}
+      - name: Install cross
+        run: cargo install cross || true
+
+      - name: check
+        run: cross check --target ${{ matrix.target }}
+
+      - name: test
+        run: cross test --target ${{ matrix.target }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -63,7 +63,7 @@ jobs:
           - i686-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
           - powerpc64le-unknown-linux-gnu
-					- x86_64-unknown-freebsd
+          - x86_64-unknown-freebsd
           # - x86_64-unknown-illumos
 
     steps:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -64,7 +64,7 @@ jobs:
           - i686-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
           - powerpc64le-unknown-linux-gnu
-					- x86_64-unknown-freebsd
+          - x86_64-unknown-freebsd
           # - x86_64-unknown-illumos
 
     steps:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -57,12 +57,14 @@ jobs:
       fail-fast: false
       matrix:
         target:
+          - aarch64-apple-ios
+          - aarch64-linux-android
+          - aarch64-pc-windows-msvc
           - i686-unknown-linux-gnu
-          - powerpc-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
           - powerpc64le-unknown-linux-gnu
-          - mips-unknown-linux-gnu
-          - arm-linux-androideabi
+					- x86_64-unknown-freebsd
+          # - x86_64-unknown-illumos
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -49,38 +49,3 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-
-  cross:
-    name: Cross compile
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - aarch64-apple-ios
-          - aarch64-linux-android
-          - aarch64-pc-windows-msvc
-          - x86_64-apple-darwin
-          - i686-unknown-linux-gnu
-          - powerpc64-unknown-linux-gnu
-          - powerpc64le-unknown-linux-gnu
-          - x86_64-unknown-freebsd
-          # - x86_64-unknown-illumos
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set current week of the year in environnement
-        run: echo "::set-env name=CURRENT_WEEK::$(date +%V)"
-
-      - name: Install nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-
-      - name: Install cross
-        run: cargo install cross || true
-
-      - name: check
-        run: cross check --target ${{ matrix.target }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,6 +20,7 @@ jobs:
           toolchain: stable
           profile: minimal
           components: clippy
+
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tokio02 = ["tokio"]
 [dependencies]
 async-task = "3.0.0"
 crossbeam = "0.7.3"
-futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.5", default-features = false, features = ["std", "io"] }
 futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 once_cell = "1.3.1"
 piper = "0.1.1"

--- a/examples/linux-inotify.rs
+++ b/examples/linux-inotify.rs
@@ -44,7 +44,7 @@ fn main() -> std::io::Result<()> {
 
         // Wait for events in a loop and print them on the screen.
         loop {
-            for event in inotify.with_mut(read_op).await? {
+            for event in inotify.read_with_mut(read_op).await? {
                 println!("{:?}", event);
             }
         }

--- a/examples/linux-timerfd.rs
+++ b/examples/linux-timerfd.rs
@@ -32,7 +32,7 @@ fn main() -> std::io::Result<()> {
 
         // When the OS timer fires, a 64-bit integer can be read from it.
         Async::new(timer)?
-            .with(|t| nix::unistd::read(t.as_raw_fd(), &mut [0u8; 8]).map_err(io_err))
+            .read_with(|t| nix::unistd::read(t.as_raw_fd(), &mut [0u8; 8]).map_err(io_err))
             .await?;
         Ok(())
     }

--- a/examples/windows-uds.rs
+++ b/examples/windows-uds.rs
@@ -40,7 +40,7 @@ fn main() -> std::io::Result<()> {
         let task = Task::spawn(client(path));
 
         // Accept the client.
-        let (stream, _) = listener.with(|l| l.accept()).await?;
+        let (stream, _) = listener.read_with(|l| l.accept()).await?;
         println!("Accepted a client");
 
         // Send a message, drop the stream, and wait for the client.

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -744,7 +744,11 @@ impl Async<TcpStream> {
         // The stream becomes writable when connected.
         stream.writable().await?;
 
-        Ok(stream)
+        // Check if there was an error while connecting.
+        match stream.get_ref().take_error()? {
+            None => Ok(stream),
+            Some(err) => Err(err),
+        }
     }
 
     /// Reads data from the stream without removing it from the buffer.

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -484,7 +484,7 @@ impl<T> Async<T> {
     /// use std::net::UdpSocket;
     ///
     /// # smol::run(async {
-    /// let socket = Async::<UdpSocket>::bind("127.0.0.1:9000")?;
+    /// let mut socket = Async::<UdpSocket>::bind("127.0.0.1:9000")?;
     /// socket.get_ref().connect("127.0.0.1:8000")?;
     ///
     /// let msg = b"hello";

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -19,8 +19,8 @@ use std::{
     path::Path,
 };
 
-use futures_util::future;
 use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::future;
 use futures_util::stream::{self, Stream};
 use socket2::{Domain, Protocol, Socket, Type};
 
@@ -217,11 +217,9 @@ impl<T: IntoRawSocket> IntoRawSocket for Async<T> {
 }
 
 impl<T> Async<T> {
-    /// Reregisters the I/O handle is registered in the reactor.
-    ///
-    /// This is a useful method when the reactor is used in oneshot mode.
-    pub(crate) fn reregister(&self) -> io::Result<()> {
-        self.source.reregister()
+    /// Re-registers the I/O event to wake the poller.
+    pub(crate) fn reregister_io_event(&self) -> io::Result<()> {
+        self.source.reregister_io_event()
     }
 
     /// Gets a reference to the inner I/O handle.
@@ -277,16 +275,107 @@ impl<T> Async<T> {
         Ok(io)
     }
 
-    /// Performs an I/O operation asynchronously.
+    #[doc(hidden)]
+    #[deprecated(note = "use `read_with()` or `write_with()` instead")]
+    pub async fn with<R>(&self, op: impl FnMut(&T) -> io::Result<R>) -> io::Result<R> {
+        let mut op = op;
+        let io = self.io.as_ref().unwrap();
+        loop {
+            match op(io) {
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+                res => return res,
+            }
+
+            // Wait until the I/O handle is readable or writable.
+            let readable = self.source.readable();
+            let writable = self.source.writable();
+            futures_util::pin_mut!(readable);
+            futures_util::pin_mut!(writable);
+            let _ = future::select(readable, writable).await;
+        }
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note = "use `read_with_mut()` or `write_with_mut()` instead")]
+    pub async fn with_mut<R>(&mut self, op: impl FnMut(&mut T) -> io::Result<R>) -> io::Result<R> {
+        let mut op = op;
+        let io = self.io.as_mut().unwrap();
+        loop {
+            match op(io) {
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+                res => return res,
+            }
+
+            // Wait until the I/O handle is readable or writable.
+            let readable = self.source.readable();
+            let writable = self.source.writable();
+            futures_util::pin_mut!(readable);
+            futures_util::pin_mut!(writable);
+            let _ = future::select(readable, writable).await;
+        }
+    }
+
+    /// Waits until the I/O handle is readable.
     ///
-    /// This I/O handle is in non-blocking mode and is registered in the reactor. It gets notified
-    /// on every new event.
+    /// This function completes when a readability event for this I/O handle is emitted by the
+    /// operating system.
     ///
-    /// The closure passed to this function attempts an I/O operation and must return
-    /// [`io::ErrorKind::WouldBlock`] if it's not ready. The current task then gets notified by the
-    /// reactor when the I/O handle is ready again and the closure retries the operation.
+    /// Keep in mind that there is a small delay between the moment the event is emitted and the
+    /// moment it is delivered to functions waiting for it. If a previous read operation has
+    /// already requested this event, it might get delivered to some function calls even after it
+    /// has been emitted.
     ///
-    /// The closure gets a shared reference to the inner I/O handle.
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use smol::Async;
+    /// use std::net::TcpListener;
+    ///
+    /// # smol::run(async {
+    /// let mut listener = Async::<TcpListener>::bind("127.0.0.1:80")?;
+    ///
+    /// // Wait until a client can be accepted.
+    /// listener.readable().await?;
+    /// # std::io::Result::Ok(()) });
+    /// ```
+    pub async fn readable(&self) -> io::Result<()> {
+        self.source.readable().await
+    }
+
+    /// Waits until the I/O handle is writable.
+    ///
+    /// This function completes when a writability event for this I/O handle is emitted by the
+    /// operating system.
+    ///
+    /// Keep in mind that there is a small delay between the moment the event is emitted and the
+    /// moment it is delivered to functions waiting for it. If a previous write operation has
+    /// already requested this event, it might get delivered to some function calls even after it
+    /// has been emitted.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use smol::Async;
+    /// use std::net::TcpStream;
+    ///
+    /// # smol::run(async {
+    /// let stream = Async::<TcpStream>::connect("example.com:80").await?;
+    ///
+    /// // Wait until the stream is writable.
+    /// stream.writable().await?;
+    /// # std::io::Result::Ok(()) });
+    /// ```
+    pub async fn writable(&self) -> io::Result<()> {
+        self.source.writable().await
+    }
+
+    /// Performs a read operation asynchronously.
+    ///
+    /// The I/O handle is registered in the reactor and put in non-blocking mode. This function
+    /// invokes the `op` closure followed by [`Async::readable()`] in a loop until the closure
+    /// succeeds or returns an error other than [`io::ErrorKind::WouldBlock`].
+    ///
+    /// The closure receives a shared reference to the I/O handle.
     ///
     /// # Examples
     ///
@@ -298,26 +387,27 @@ impl<T> Async<T> {
     /// let listener = Async::<TcpListener>::bind("127.0.0.1:80")?;
     ///
     /// // Accept a new client asynchronously.
-    /// let (stream, addr) = listener.with(|l| l.accept()).await?;
+    /// let (stream, addr) = listener.read_with(|l| l.accept()).await?;
     /// # std::io::Result::Ok(()) });
     /// ```
-    pub async fn with<R>(&self, op: impl FnMut(&T) -> io::Result<R>) -> io::Result<R> {
+    pub async fn read_with<R>(&self, op: impl FnMut(&T) -> io::Result<R>) -> io::Result<R> {
         let mut op = op;
-        let mut io = self.io.as_ref().unwrap();
-        let source = &self.source;
-        future::poll_fn(|cx| source.poll_io(cx, || op(&mut io))).await
+        loop {
+            match op(self.get_ref()) {
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+                res => return res,
+            }
+            self.source.readable().await?;
+        }
     }
 
-    /// Performs an I/O operation asynchronously.
+    /// Performs a read operation asynchronously.
     ///
-    /// This I/O handle is in non-blocking mode and is registered in the reactor. It gets notified
-    /// on every new event.
+    /// The I/O handle is registered in the reactor and put in non-blocking mode. This function
+    /// invokes the `op` closure followed by [`Async::readable()`] in a loop until the closure
+    /// succeeds or returns an error other than [`io::ErrorKind::WouldBlock`].
     ///
-    /// The closure passed to this function attempts an I/O operation and must return
-    /// [`io::ErrorKind::WouldBlock`] if it's not ready. The current task then gets notified by the
-    /// reactor when the I/O handle is ready again and the closure retries the operation.
-    ///
-    /// The closure gets a mutable reference to the inner I/O handle.
+    /// The closure receives a mutable reference to the I/O handle.
     ///
     /// # Examples
     ///
@@ -329,14 +419,90 @@ impl<T> Async<T> {
     /// let mut listener = Async::<TcpListener>::bind("127.0.0.1:80")?;
     ///
     /// // Accept a new client asynchronously.
-    /// let (stream, addr) = listener.with_mut(|l| l.accept()).await?;
+    /// let (stream, addr) = listener.read_with_mut(|l| l.accept()).await?;
     /// # std::io::Result::Ok(()) });
     /// ```
-    pub async fn with_mut<R>(&mut self, op: impl FnMut(&mut T) -> io::Result<R>) -> io::Result<R> {
+    pub async fn read_with_mut<R>(
+        &mut self,
+        op: impl FnMut(&mut T) -> io::Result<R>,
+    ) -> io::Result<R> {
         let mut op = op;
-        let mut io = self.io.as_mut().unwrap();
-        let source = &self.source;
-        future::poll_fn(|cx| source.poll_io(cx, || op(&mut io))).await
+        loop {
+            match op(self.get_mut()) {
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+                res => return res,
+            }
+            self.source.readable().await?;
+        }
+    }
+
+    /// Performs a write operation asynchronously.
+    ///
+    /// The I/O handle is registered in the reactor and put in non-blocking mode. This function
+    /// invokes the `op` closure followed by [`Async::writable()`] in a loop until the closure
+    /// succeeds or returns an error other than [`io::ErrorKind::WouldBlock`].
+    ///
+    /// The closure receives a shared reference to the I/O handle.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use smol::Async;
+    /// use std::net::UdpSocket;
+    ///
+    /// # smol::run(async {
+    /// let socket = Async::<UdpSocket>::bind("127.0.0.1:9000")?;
+    /// socket.get_ref().connect("127.0.0.1:8000")?;
+    ///
+    /// let msg = b"hello";
+    /// let len = socket.write_with(|s| s.send(msg)).await?;
+    /// # std::io::Result::Ok(()) });
+    /// ```
+    pub async fn write_with<R>(&self, op: impl FnMut(&T) -> io::Result<R>) -> io::Result<R> {
+        let mut op = op;
+        loop {
+            match op(self.get_ref()) {
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+                res => return res,
+            }
+            self.source.writable().await?;
+        }
+    }
+
+    /// Performs a write operation asynchronously.
+    ///
+    /// The I/O handle is registered in the reactor and put in non-blocking mode. This function
+    /// invokes the `op` closure followed by [`Async::writable()`] in a loop until the closure
+    /// succeeds or returns an error other than [`io::ErrorKind::WouldBlock`].
+    ///
+    /// The closure receives a mutable reference to the I/O handle.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use smol::Async;
+    /// use std::net::UdpSocket;
+    ///
+    /// # smol::run(async {
+    /// let socket = Async::<UdpSocket>::bind("127.0.0.1:9000")?;
+    /// socket.get_ref().connect("127.0.0.1:8000")?;
+    ///
+    /// let msg = b"hello";
+    /// let len = socket.write_with_mut(|s| s.send(msg)).await?;
+    /// # std::io::Result::Ok(()) });
+    /// ```
+    pub async fn write_with_mut<R>(
+        &mut self,
+        op: impl FnMut(&mut T) -> io::Result<R>,
+    ) -> io::Result<R> {
+        let mut op = op;
+        loop {
+            match op(self.get_mut()) {
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+                res => return res,
+            }
+            self.source.writable().await?;
+        }
     }
 }
 
@@ -364,7 +530,7 @@ impl<T: Read> AsyncRead for Async<T> {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        poll_future(cx, self.with_mut(|io| io.read(buf)))
+        poll_future(cx, self.read_with_mut(|io| io.read(buf)))
     }
 
     fn poll_read_vectored(
@@ -372,7 +538,7 @@ impl<T: Read> AsyncRead for Async<T> {
         cx: &mut Context<'_>,
         bufs: &mut [IoSliceMut<'_>],
     ) -> Poll<io::Result<usize>> {
-        poll_future(cx, self.with_mut(|io| io.read_vectored(bufs)))
+        poll_future(cx, self.read_with_mut(|io| io.read_vectored(bufs)))
     }
 }
 
@@ -385,7 +551,7 @@ where
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        poll_future(cx, self.with(|io| (&*io).read(buf)))
+        poll_future(cx, self.read_with(|io| (&*io).read(buf)))
     }
 
     fn poll_read_vectored(
@@ -393,7 +559,7 @@ where
         cx: &mut Context<'_>,
         bufs: &mut [IoSliceMut<'_>],
     ) -> Poll<io::Result<usize>> {
-        poll_future(cx, self.with(|io| (&*io).read_vectored(bufs)))
+        poll_future(cx, self.read_with(|io| (&*io).read_vectored(bufs)))
     }
 }
 
@@ -403,7 +569,7 @@ impl<T: Write> AsyncWrite for Async<T> {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        poll_future(cx, self.with_mut(|io| io.write(buf)))
+        poll_future(cx, self.write_with_mut(|io| io.write(buf)))
     }
 
     fn poll_write_vectored(
@@ -411,11 +577,11 @@ impl<T: Write> AsyncWrite for Async<T> {
         cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        poll_future(cx, self.with_mut(|io| io.write_vectored(bufs)))
+        poll_future(cx, self.write_with_mut(|io| io.write_vectored(bufs)))
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        poll_future(cx, self.with_mut(|io| io.flush()))
+        poll_future(cx, self.write_with_mut(|io| io.flush()))
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -432,7 +598,7 @@ where
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        poll_future(cx, self.with(|io| (&*io).write(buf)))
+        poll_future(cx, self.write_with(|io| (&*io).write(buf)))
     }
 
     fn poll_write_vectored(
@@ -440,11 +606,11 @@ where
         cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        poll_future(cx, self.with(|io| (&*io).write_vectored(bufs)))
+        poll_future(cx, self.write_with(|io| (&*io).write_vectored(bufs)))
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        poll_future(cx, self.with(|io| (&*io).flush()))
+        poll_future(cx, self.write_with(|io| (&*io).flush()))
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -494,7 +660,7 @@ impl Async<TcpListener> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub async fn accept(&self) -> io::Result<(Async<TcpStream>, SocketAddr)> {
-        let (stream, addr) = self.with(|io| io.accept()).await?;
+        let (stream, addr) = self.read_with(|io| io.accept()).await?;
         Ok((Async::new(stream)?, addr))
     }
 
@@ -575,29 +741,8 @@ impl Async<TcpStream> {
         })?;
         let stream = Async::new(socket.into_tcp_stream())?;
 
-        // Wait for connect to complete.
-        let wait_connect = |mut stream: &TcpStream| match stream.write(&[]) {
-            Err(err) if err.kind() == io::ErrorKind::NotConnected => {
-                // On other systems, if a non-blocking connect call fails, a
-                // sensible error code is returned by the send (write) call.
-                //
-                // But not on Windows. If a non-blocking connect call fails, the
-                // send call always returns NotConnected. We have to use
-                // take_error (i.e., getsockopt SO_ERROR) to find out whether
-                // the connect call has failed, and retrieve the error code if
-                // it has.
-                #[cfg(windows)]
-                {
-                    if let Some(e) = stream.take_error()? {
-                        return Err(e);
-                    }
-                }
-                Err(io::ErrorKind::WouldBlock.into())
-            }
-            res => res.map(|_| ()),
-        };
         // The stream becomes writable when connected.
-        stream.with(|io| wait_connect(io)).await?;
+        stream.writable().await?;
 
         Ok(stream)
     }
@@ -620,7 +765,7 @@ impl Async<TcpStream> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub async fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.with(|io| io.peek(buf)).await
+        self.read_with(|io| io.peek(buf)).await
     }
 }
 
@@ -669,7 +814,7 @@ impl Async<UdpSocket> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
-        self.with(|io| io.recv_from(buf)).await
+        self.read_with(|io| io.recv_from(buf)).await
     }
 
     /// Receives a single datagram message without removing it from the queue.
@@ -693,7 +838,7 @@ impl Async<UdpSocket> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub async fn peek_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
-        self.with(|io| io.peek_from(buf)).await
+        self.read_with(|io| io.peek_from(buf)).await
     }
 
     /// Sends data to the specified address.
@@ -716,7 +861,7 @@ impl Async<UdpSocket> {
     /// ```
     pub async fn send_to<A: Into<SocketAddr>>(&self, buf: &[u8], addr: A) -> io::Result<usize> {
         let addr = addr.into();
-        self.with(|io| io.send_to(buf, addr)).await
+        self.write_with(|io| io.send_to(buf, addr)).await
     }
 
     /// Receives a single datagram message from the connected peer.
@@ -744,7 +889,7 @@ impl Async<UdpSocket> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.with(|io| io.recv(buf)).await
+        self.write_with(|io| io.recv(buf)).await
     }
 
     /// Receives a single datagram message from the connected peer without removing it from the
@@ -773,7 +918,7 @@ impl Async<UdpSocket> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub async fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.with(|io| io.peek(buf)).await
+        self.read_with(|io| io.peek(buf)).await
     }
 
     /// Sends data to the connected peer.
@@ -798,7 +943,7 @@ impl Async<UdpSocket> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
-        self.with(|io| io.send(buf)).await
+        self.write_with(|io| io.send(buf)).await
     }
 }
 
@@ -840,7 +985,7 @@ impl Async<UnixListener> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub async fn accept(&self) -> io::Result<(Async<UnixStream>, UnixSocketAddr)> {
-        let (stream, addr) = self.with(|io| io.accept()).await?;
+        let (stream, addr) = self.read_with(|io| io.accept()).await?;
         Ok((Async::new(stream)?, addr))
     }
 
@@ -906,15 +1051,8 @@ impl Async<UnixStream> {
             })?;
         let stream = Async::new(socket.into_unix_stream())?;
 
-        // Wait for connect to complete.
-        let wait_connect = |mut stream: &UnixStream| match stream.write(&[]) {
-            Err(err) if err.kind() == io::ErrorKind::NotConnected => {
-                Err(io::ErrorKind::WouldBlock.into())
-            }
-            res => res.map(|_| ()),
-        };
         // The stream becomes writable when connected.
-        stream.with(|io| wait_connect(io)).await?;
+        stream.writable().await?;
 
         Ok(stream)
     }
@@ -1007,7 +1145,7 @@ impl Async<UnixDatagram> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, UnixSocketAddr)> {
-        self.with(|io| io.recv_from(buf)).await
+        self.read_with(|io| io.recv_from(buf)).await
     }
 
     /// Sends data to the specified address.
@@ -1029,7 +1167,7 @@ impl Async<UnixDatagram> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub async fn send_to<P: AsRef<Path>>(&self, buf: &[u8], path: P) -> io::Result<usize> {
-        self.with(|io| io.send_to(buf, &path)).await
+        self.write_with(|io| io.send_to(buf, &path)).await
     }
 
     /// Receives data from the connected peer.
@@ -1054,7 +1192,7 @@ impl Async<UnixDatagram> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.with(|io| io.recv(buf)).await
+        self.read_with(|io| io.recv(buf)).await
     }
 
     /// Sends data to the connected peer.
@@ -1079,6 +1217,6 @@ impl Async<UnixDatagram> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
-        self.with(|io| io.send(buf)).await
+        self.write_with(|io| io.send(buf)).await
     }
 }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -627,16 +627,16 @@ mod sys {
     impl Events {
         pub fn new() -> Events {
             let flags = EventFlag::empty();
-            let event = KEvent::new(0, EventFilter::EVFILT_USER, flags, FFLAGS, 0, 0);
+            let event = KEvent::new(0, EventFilter::empty(), flags, FFLAGS, 0, 0);
             let list = vec![event; 1000].into_boxed_slice();
             let len = 0;
             Events { list, len }
         }
         pub fn iter(&self) -> impl Iterator<Item = Event> + '_ {
             self.list[..self.len].iter().map(|ev| Event {
-                readable: ev.filter() != EventFilter::EVFILT_WRITE,
-                writable: ev.filter() != EventFilter::EVFILT_READ,
-                key: ev.data() as usize,
+                readable: ev.filter() == EventFilter::EVFILT_READ,
+                writable: ev.filter() == EventFilter::EVFILT_WRITE,
+                key: ev.udata() as usize,
             })
         }
     }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -627,7 +627,7 @@ mod sys {
     impl Events {
         pub fn new() -> Events {
             let flags = EventFlag::empty();
-            let event = KEvent::new(0, EventFilter::empty(), flags, FFLAGS, 0, 0);
+            let event = KEvent::new(0, EventFilter::EVFILT_USER, flags, FFLAGS, 0, 0);
             let list = vec![event; 1000].into_boxed_slice();
             let len = 0;
             Events { list, len }
@@ -636,7 +636,7 @@ mod sys {
             self.list[..self.len].iter().map(|ev| Event {
                 readable: ev.filter() == EventFilter::EVFILT_READ,
                 writable: ev.filter() == EventFilter::EVFILT_WRITE,
-                key: ev.udata() as usize,
+                key: ev.rdata() as usize,
             })
         }
     }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -636,7 +636,7 @@ mod sys {
             self.list[..self.len].iter().map(|ev| Event {
                 readable: ev.filter() == EventFilter::EVFILT_READ,
                 writable: ev.filter() == EventFilter::EVFILT_WRITE,
-                key: ev.rdata() as usize,
+                key: ev.udata() as usize,
             })
         }
     }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -27,10 +27,11 @@ use std::os::unix::io::RawFd;
 use std::os::windows::io::{FromRawSocket, RawSocket};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::task::{Context, Poll, Waker};
+use std::task::{Poll, Waker};
 use std::time::{Duration, Instant};
 
 use crossbeam::queue::ArrayQueue;
+use futures_util::future;
 #[cfg(unix)]
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use once_cell::sync::Lazy;
@@ -39,7 +40,6 @@ use slab::Slab;
 use socket2::Socket;
 
 use crate::io_event::IoEvent;
-use crate::throttle;
 
 /// The reactor.
 ///
@@ -51,8 +51,8 @@ pub(crate) struct Reactor {
     /// Raw bindings to epoll/kqueue/wepoll.
     sys: sys::Reactor,
 
-    /// Registered sources.
-    sources: piper::Mutex<Slab<Arc<Source>>>,
+    /// Registered I/O sources.
+    sources: piper::Mutex<Sources>,
 
     /// Temporary storage for I/O events when polling the reactor.
     events: piper::Lock<sys::Events>,
@@ -77,12 +77,27 @@ pub(crate) struct Reactor {
     timer_event: Lazy<IoEvent>,
 }
 
+/// Registered I/O sources.
+struct Sources {
+    /// Incremented on registration.
+    ///
+    /// This is used to tag I/O handles in order to distinguish between new and old sources that
+    /// use the same index into the table.
+    tick: u32,
+
+    /// The table of registered I/O sources.
+    table: Slab<Arc<Source>>,
+}
+
 impl Reactor {
     /// Returns a reference to the reactor.
     pub fn get() -> &'static Reactor {
         static REACTOR: Lazy<Reactor> = Lazy::new(|| Reactor {
             sys: sys::Reactor::new().expect("cannot initialize I/O event notification"),
-            sources: piper::Mutex::new(Slab::new()),
+            sources: piper::Mutex::new(Sources {
+                tick: 0,
+                table: Slab::new(),
+            }),
             events: piper::Lock::new(sys::Events::new()),
             timers: piper::Mutex::new(BTreeMap::new()),
             timer_ops: ArrayQueue::new(1000),
@@ -98,7 +113,23 @@ impl Reactor {
         #[cfg(windows)] raw: RawSocket,
     ) -> io::Result<Arc<Source>> {
         let mut sources = self.sources.lock();
-        let vacant = sources.vacant_entry();
+
+        // Bump the ticker.
+        let tick = sources.tick;
+        sources.tick = tick.wrapping_add(1);
+
+        // Find a vacant entry in the table.
+        let vacant = sources.table.vacant_entry();
+        let index = vacant.key();
+        assert!(
+            index < u32::max_value() as usize,
+            "too many registered I/O handles"
+        );
+
+        // The key identifying this I/O source.
+        //
+        // Lower 32 bits contain the index into the table and the upper 32 bits contain the tag.
+        let key = index as u64 | ((tick as u64) << 32);
 
         // Put the I/O handle in non-blocking mode.
         #[cfg(unix)]
@@ -116,9 +147,13 @@ impl Reactor {
         // Create a source and register it.
         let source = Arc::new(Source {
             raw,
-            key: vacant.key(),
-            wakers: piper::Mutex::new(Vec::new()),
-            tick: AtomicUsize::new(0),
+            key,
+            wakers: piper::Mutex::new(Wakers {
+                tick_readable: 0,
+                tick_writable: 0,
+                readers: Vec::new(),
+                writers: Vec::new(),
+            }),
         });
         self.sys.register(raw, source.key)?;
 
@@ -128,7 +163,11 @@ impl Reactor {
     /// Deregisters an I/O source from the reactor.
     pub fn remove_io(&self, source: &Source) -> io::Result<()> {
         let mut sources = self.sources.lock();
-        sources.remove(source.key);
+
+        // Lower 32 bits of the key contain the index into the table.
+        let index = source.key as u32 as usize;
+
+        sources.table.remove(index);
         self.sys.deregister(source.raw)
     }
 
@@ -271,15 +310,33 @@ impl ReactorLock<'_> {
                     // Iterate over sources in the event list.
                     let sources = self.reactor.sources.lock();
 
-                    for source in self.events.iter().filter_map(|i| sources.get(i)) {
-                        // Bump the ticker.
-                        let mut wakers = source.wakers.lock();
-                        let tick = source.tick.load(Ordering::Acquire);
-                        source.tick.store(tick.wrapping_add(1), Ordering::Release);
+                    for ev in self.events.iter() {
+                        // Lower 32 bits of the key contain the index into the table.
+                        let index = ev.key as u32 as usize;
 
-                        // Wake up tasks waiting on I/O.
-                        for w in wakers.drain(..) {
-                            w.wake();
+                        // Check if there is a source in the table at this index.
+                        if let Some(source) = sources.table.get(index) {
+                            // Check if the key matches. If it doesn't that means we got a stale
+                            // event for an old source that was previously stored at this index.
+                            if source.key == ev.key {
+                                let mut wakers = source.wakers.lock();
+
+                                // Wake readers if a readability event was emitted.
+                                if ev.readable {
+                                    wakers.tick_readable += 1;
+                                    for w in wakers.readers.drain(..) {
+                                        w.wake();
+                                    }
+                                }
+
+                                // Wake writers if a writability event was emitted.
+                                if ev.writable {
+                                    wakers.tick_writable += 1;
+                                    for w in wakers.writers.drain(..) {
+                                        w.wake();
+                                    }
+                                }
+                            }
                         }
                     }
 
@@ -313,62 +370,116 @@ pub(crate) struct Source {
     #[cfg(windows)]
     pub(crate) raw: RawSocket,
 
-    /// The ID of this source obtain during registration.
-    key: usize,
+    /// The ID of this source obtained during registration.
+    ///
+    /// Lower 32 bits contain the index into the table of sources. Upper 32 bits is just an extra
+    /// tag to distinguish between new and old sources that use the same index.
+    key: u64,
 
-    /// A list of wakers representing tasks interested in events on this source.
-    wakers: piper::Mutex<Vec<Waker>>,
+    /// Tasks interested in events on this source.
+    wakers: piper::Mutex<Wakers>,
+}
 
-    /// Incremented on every I/O notification - this is only used for synchronization.
-    tick: AtomicUsize,
+/// Tasks interested in events on a source.
+#[derive(Debug)]
+struct Wakers {
+    /// Number of delivered readability events.
+    tick_readable: u64,
+
+    /// Number of delivered writability events.
+    tick_writable: u64,
+
+    /// Tasks waiting for the next readability event.
+    readers: Vec<Waker>,
+
+    /// Tasks waiting for the next writability event.
+    writers: Vec<Waker>,
 }
 
 impl Source {
-    /// Reregisters the I/O handle is registered in the reactor.
-    ///
-    /// This is a useful method when the reactor is used in oneshot mode.
-    pub(crate) fn reregister(&self) -> io::Result<()> {
-        Reactor::get().sys.reregister(self.raw, self.key)
+    /// Re-registers the I/O event to wake the poller.
+    pub(crate) fn reregister_io_event(&self) -> io::Result<()> {
+        let wakers = self.wakers.lock();
+        Reactor::get()
+            .sys
+            .reregister(self.raw, self.key, true, !wakers.writers.is_empty())?;
+        Ok(())
     }
 
-    /// Attempts a non-blocking I/O operation and registers a waker if it errors with `WouldBlock`.
-    pub fn poll_io<R>(
-        &self,
-        cx: &mut Context<'_>,
-        mut op: impl FnMut() -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
-        // Throttle if the current task did too many I/O operations without yielding.
-        futures_util::ready!(throttle::poll(cx));
+    /// Waits until the I/O source is readable.
+    pub(crate) async fn readable(&self) -> io::Result<()> {
+        let mut tick = None;
 
-        loop {
-            // This number is bumped just before I/O notifications while wakers are locked.
-            let tick = self.tick.load(Ordering::Acquire);
+        future::poll_fn(|cx| match tick {
+            None => {
+                let mut wakers = self.wakers.lock();
 
-            // Attempt the non-blocking operation.
-            match op() {
-                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-                res => return Poll::Ready(res),
-            }
-
-            // Lock the waker list and retry the non-blocking operation.
-            let mut wakers = self.wakers.lock();
-
-            // If the current task is already registered, return.
-            if wakers.iter().any(|w| w.will_wake(cx.waker())) {
-                return Poll::Pending;
-            }
-
-            // If there were no new notifications, register and return.
-            if self.tick.load(Ordering::Acquire) == tick {
-                if wakers.is_empty() {
-                    // Re-register the I/O handle if it's in oneshot mode.
-                    self.reregister()?;
+                // If there are no other readers, re-register in the reactor.
+                if wakers.readers.is_empty() {
+                    Reactor::get().sys.reregister(
+                        self.raw,
+                        self.key,
+                        true,
+                        !wakers.writers.is_empty(),
+                    )?;
                 }
 
-                wakers.push(cx.waker().clone());
-                return Poll::Pending;
+                // Register the current task's waker if not present already.
+                if wakers.readers.iter().all(|w| !w.will_wake(cx.waker())) {
+                    wakers.readers.push(cx.waker().clone());
+                }
+
+                // Record the readability tick to wait for.
+                tick = Some(wakers.tick_readable + 1);
+                Poll::Pending
             }
-        }
+            Some(tick) => {
+                if self.wakers.lock().tick_readable < tick {
+                    Poll::Pending
+                } else {
+                    Poll::Ready(Ok(()))
+                }
+            }
+        })
+        .await
+    }
+
+    /// Waits until the I/O source is writable.
+    pub(crate) async fn writable(&self) -> io::Result<()> {
+        let mut tick = None;
+
+        future::poll_fn(|cx| match tick {
+            None => {
+                let mut wakers = self.wakers.lock();
+
+                // If there are no other writers, re-register in the reactor.
+                if wakers.writers.is_empty() {
+                    Reactor::get().sys.reregister(
+                        self.raw,
+                        self.key,
+                        !wakers.readers.is_empty(),
+                        true,
+                    )?;
+                }
+
+                // Register the current task's waker if not present already.
+                if wakers.writers.iter().all(|w| !w.will_wake(cx.waker())) {
+                    wakers.writers.push(cx.waker().clone());
+                }
+
+                // Record the writability tick to wait for.
+                tick = Some(wakers.tick_writable + 1);
+                Poll::Pending
+            }
+            Some(tick) => {
+                if self.wakers.lock().tick_writable < tick {
+                    Poll::Pending
+                } else {
+                    Poll::Ready(Ok(()))
+                }
+            }
+        })
+        .await
     }
 }
 
@@ -401,12 +512,20 @@ mod sys {
             let epoll_fd = epoll_create1(EpollCreateFlags::EPOLL_CLOEXEC).map_err(io_err)?;
             Ok(Reactor(epoll_fd))
         }
-        pub fn register(&self, fd: RawFd, key: usize) -> io::Result<()> {
-            let ev = &mut EpollEvent::new(flags(), key as u64);
+        pub fn register(&self, fd: RawFd, key: u64) -> io::Result<()> {
+            let ev = &mut EpollEvent::new(EpollFlags::empty(), key);
             epoll_ctl(self.0, EpollOp::EpollCtlAdd, fd, Some(ev)).map_err(io_err)
         }
-        pub fn reregister(&self, _fd: RawFd, _key: usize) -> io::Result<()> {
-            Ok(())
+        pub fn reregister(&self, fd: RawFd, key: u64, read: bool, write: bool) -> io::Result<()> {
+            let mut flags = EpollFlags::EPOLLONESHOT;
+            if read {
+                flags |= read_flags();
+            }
+            if write {
+                flags |= write_flags();
+            }
+            let ev = &mut EpollEvent::new(flags, key);
+            epoll_ctl(self.0, EpollOp::EpollCtlMod, fd, Some(ev)).map_err(io_err)
         }
         pub fn deregister(&self, fd: RawFd) -> io::Result<()> {
             epoll_ctl(self.0, EpollOp::EpollCtlDel, fd, None).map_err(io_err)
@@ -426,8 +545,11 @@ mod sys {
             Ok(events.len)
         }
     }
-    fn flags() -> EpollFlags {
-        EpollFlags::EPOLLET | EpollFlags::EPOLLIN | EpollFlags::EPOLLOUT | EpollFlags::EPOLLRDHUP
+    fn read_flags() -> EpollFlags {
+        EpollFlags::EPOLLIN | EpollFlags::EPOLLRDHUP
+    }
+    fn write_flags() -> EpollFlags {
+        EpollFlags::EPOLLOUT
     }
 
     pub struct Events {
@@ -440,9 +562,18 @@ mod sys {
             let len = 0;
             Events { list, len }
         }
-        pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
-            self.list[..self.len].iter().map(|ev| ev.data() as usize)
+        pub fn iter(&self) -> impl Iterator<Item = Event> + '_ {
+            self.list[..self.len].iter().map(|ev| Event {
+                readable: ev.events().intersects(read_flags()),
+                writable: ev.events().intersects(write_flags()),
+                key: ev.data(),
+            })
         }
+    }
+    pub struct Event {
+        pub readable: bool,
+        pub writable: bool,
+        pub key: u64,
     }
 }
 
@@ -474,25 +605,54 @@ mod sys {
             fcntl(fd, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)).map_err(io_err)?;
             Ok(Reactor(fd))
         }
-        pub fn register(&self, fd: RawFd, key: usize) -> io::Result<()> {
-            let flags = EventFlag::EV_CLEAR | EventFlag::EV_RECEIPT | EventFlag::EV_ADD;
-            let udata = key as _;
+        pub fn register(&self, fd: RawFd, key: u64) -> io::Result<()> {
+            Ok(())
+        }
+        pub fn reregister(&self, fd: RawFd, key: u64, read: bool, write: bool) -> io::Result<()> {
+            let mut read_flags = EventFlag::EV_ONESHOT | EventFlag::EV_RECEIPT;
+            let mut write_flags = EventFlag::EV_ONESHOT | EventFlag::EV_RECEIPT;
+            if read {
+                read_flags |= EventFlag::EV_ADD;
+            } else {
+                read_flags |= EventFlag::EV_DELETE;
+            }
+            if write {
+                write_flags |= EventFlag::EV_ADD;
+            } else {
+                write_flags |= EventFlag::EV_DELETE;
+            }
+            let udata = key;
             let changelist = [
-                KEvent::new(fd as _, EventFilter::EVFILT_WRITE, flags, FFLAGS, 0, udata),
-                KEvent::new(fd as _, EventFilter::EVFILT_READ, flags, FFLAGS, 0, udata),
+                KEvent::new(
+                    fd as _,
+                    EventFilter::EVFILT_READ,
+                    read_flags,
+                    FFLAGS,
+                    0,
+                    udata,
+                ),
+                KEvent::new(
+                    fd as _,
+                    EventFilter::EVFILT_WRITE,
+                    write_flags,
+                    FFLAGS,
+                    0,
+                    udata,
+                ),
             ];
             let mut eventlist = changelist;
             kevent_ts(self.0, &changelist, &mut eventlist, None).map_err(io_err)?;
             for ev in &eventlist {
-                // See https://github.com/tokio-rs/mio/issues/582
+                // Explanation for ignoring EPIPE: https://github.com/tokio-rs/mio/issues/582
                 let (flags, data) = (ev.flags(), ev.data());
-                if flags.contains(EventFlag::EV_ERROR) && data != 0 && data != Errno::EPIPE as _ {
+                if flags.contains(EventFlag::EV_ERROR)
+                    && data != 0
+                    && data != Errno::ENOENT as _
+                    && data != Errno::EPIPE as _
+                {
                     return Err(io::Error::from_raw_os_error(data as _));
                 }
             }
-            Ok(())
-        }
-        pub fn reregister(&self, _fd: RawFd, _key: usize) -> io::Result<()> {
             Ok(())
         }
         pub fn deregister(&self, fd: RawFd) -> io::Result<()> {
@@ -505,7 +665,7 @@ mod sys {
             kevent_ts(self.0, &changelist, &mut eventlist, None).map_err(io_err)?;
             for ev in &eventlist {
                 let (flags, data) = (ev.flags(), ev.data());
-                if flags.contains(EventFlag::EV_ERROR) && data != 0 {
+                if flags.contains(EventFlag::EV_ERROR) && data != 0 && data != Errno::ENOENT as _ {
                     return Err(io::Error::from_raw_os_error(data as _));
                 }
             }
@@ -534,9 +694,18 @@ mod sys {
             let len = 0;
             Events { list, len }
         }
-        pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
-            self.list[..self.len].iter().map(|ev| ev.udata() as usize)
+        pub fn iter(&self) -> impl Iterator<Item = Event> + '_ {
+            self.list[..self.len].iter().map(|ev| Event {
+                readable: ev.filter() != EventFilter::EVFILT_WRITE,
+                writable: ev.filter() != EventFilter::EVFILT_READ,
+                key: ev.data(),
+            })
         }
+    }
+    pub struct Event {
+        pub readable: bool,
+        pub writable: bool,
+        pub key: u64,
     }
 }
 
@@ -554,18 +723,27 @@ mod sys {
         pub fn new() -> io::Result<Reactor> {
             Ok(Reactor(Epoll::new()?))
         }
-        pub fn register(&self, sock: RawSocket, key: usize) -> io::Result<()> {
-            self.0.register(&As(sock), flags(), key as u64)
+        pub fn register(&self, sock: RawSocket, key: u64) -> io::Result<()> {
+            self.0.register(&As(sock), EventFlag::empty(), key);
         }
-        pub fn reregister(&self, sock: RawSocket, key: usize) -> io::Result<()> {
-            // Ignore errors because a concurrent poll can reregister the handle at any point.
-            let _ = self.0.reregister(&As(sock), flags(), key as u64);
-            Ok(())
+        pub fn reregister(
+            &self,
+            sock: RawSocket,
+            key: u64,
+            read: bool,
+            write: bool,
+        ) -> io::Result<()> {
+            let mut flags = EventFlag::ONESHOT;
+            if read {
+                flags |= read_flags();
+            }
+            if write {
+                flags |= write_flags();
+            }
+            self.0.reregister(&As(sock), flags, key)
         }
         pub fn deregister(&self, sock: RawSocket) -> io::Result<()> {
-            // Ignore errors because an event can deregister the handle at any point.
-            let _ = self.0.deregister(&As(sock));
-            Ok(())
+            self.0.deregister(&As(sock))
         }
         pub fn wait(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<usize> {
             let timeout = timeout.map(|t| {
@@ -585,8 +763,11 @@ mod sys {
             self.0
         }
     }
-    fn flags() -> EventFlag {
-        EventFlag::ONESHOT | EventFlag::IN | EventFlag::OUT | EventFlag::RDHUP
+    fn read_flags() -> EventFlag {
+        EventFlag::IN | EventFlag::RDHUP
+    }
+    fn write_flags() -> EventFlag {
+        EventFlag::OUT
     }
 
     pub struct Events(wepoll_binding::Events);
@@ -594,8 +775,17 @@ mod sys {
         pub fn new() -> Events {
             Events(wepoll_binding::Events::with_capacity(1000))
         }
-        pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
-            self.0.iter().map(|ev| ev.data() as usize)
+        pub fn iter(&self) -> impl Iterator<Item = Event> + '_ {
+            self.0.iter().map(|ev| Event {
+                readable: ev.flags().intersects(read_flags()),
+                writable: ev.flags().intersects(write_flags()),
+                index: ev.data(),
+            })
         }
+    }
+    pub struct Event {
+        pub readable: bool,
+        pub writable: bool,
+        pub key: u64,
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -190,6 +190,9 @@ pub fn run<T>(future: impl Future<Output = T>) -> T {
             // Block until either the reactor is locked or `local.event()` is triggered.
             if let Either::Left((reactor_lock, _)) = block_on(future::select(lock, notified)) {
                 react(reactor_lock, &io_events, false);
+            } else {
+                // Clear `local.event()` because it was triggered.
+                local.event().clear();
             }
         }
     })


### PR DESCRIPTION
This also adds `Async::readable()` and `Async::writable()` functions.
This should also fix the 100% CPU usage bug on windows.

The reactor is now always working in oneshot mode rather than edge-triggered mode.

Closes #111 
Closes #122 

cc @dignifiedquire @sopium @jimblandy Wanna check if this resolves the issue on your machines too?