### PR TITLE
fix build with piper 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tokio02 = ["tokio"]
 [dependencies]
 async-task = "3.0.0"
 crossbeam = "0.7.3"
-futures-util = { version = "0.3.5", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.5", default-features = false, features = ["std", "io"] }
 futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 once_cell = "1.3.1"
 piper = "0.1.1"


### PR DESCRIPTION
piper 0.1.1 used `futures` which pulled in the `io` feature of `futures-util`.

Inside of the smol repository, `futures` is listed as dev-dependency, so it behaves the same.

Any project with smol as dependency which has no dependency pulling in the `io` feature from `futures-util` fails though since piper 0.1.2 doesn't pull it anymore and smol doesn't list it whilst using it.

With just a `cargo new` + adding smol as a dep, build fails with

```
error[E0432]: unresolved import `futures_util::io`
  --> /home/keruspe/.cargo/registry/src/github.com-1ecc6299db9ec823/smol-0.1.8/src/blocking.rs:32:19
   |
32 | use futures_util::io::{AllowStdIo, AsyncRead, AsyncWrite, AsyncWriteExt};
   |                   ^^ could not find `io` in `futures_util`

error[E0433]: failed to resolve: could not find `io` in `futures_util`
   --> /home/keruspe/.cargo/registry/src/github.com-1ecc6299db9ec823/smol-0.1.8/src/blocking.rs:359:49
    |
359 |                         let res = futures_util::io::copy(&mut io, &mut writer).await;
    |                                                 ^^ could not find `io` in `futures_util`

error[E0433]: failed to resolve: could not find `io` in `futures_util`
   --> /home/keruspe/.cargo/registry/src/github.com-1ecc6299db9ec823/smol-0.1.8/src/blocking.rs:461:41
    |
461 |                     match futures_util::io::copy(reader, &mut io).await {
    |                                         ^^ could not find `io` in `futures_util`

error: aborting due to 3 previous errors
```