### PR TITLE
refactor: replace nix with libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ optional = true
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.17.0"
+libc = "0.2.70"
 
 [target.'cfg(windows)'.dependencies]
 wepoll-binding = "2.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ features = ["rt-threaded"]
 optional = true
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.17.0"
 libc = "0.2.70"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -678,7 +678,7 @@ impl Async<TcpStream> {
         socket.connect(&addr.into()).or_else(|err| {
             // Check for EINPROGRESS on Unix and WSAEWOULDBLOCK on Windows.
             #[cfg(unix)]
-            let in_progress = err.raw_os_error() == Some(nix::libc::EINPROGRESS);
+            let in_progress = err.raw_os_error() == Some(crate::sys::libc::EINPROGRESS);
             #[cfg(windows)]
             let in_progress = err.kind() == io::ErrorKind::WouldBlock;
 
@@ -1006,7 +1006,7 @@ impl Async<UnixStream> {
         socket
             .connect(&socket2::SockAddr::unix(path)?)
             .or_else(|err| {
-                if err.raw_os_error() == Some(nix::libc::EINPROGRESS) {
+                if err.raw_os_error() == Some(crate::sys::libc::EINPROGRESS) {
                     Ok(())
                 } else {
                     Err(err)

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -678,7 +678,7 @@ impl Async<TcpStream> {
         socket.connect(&addr.into()).or_else(|err| {
             // Check for EINPROGRESS on Unix and WSAEWOULDBLOCK on Windows.
             #[cfg(unix)]
-            let in_progress = err.raw_os_error() == Some(crate::sys::libc::EINPROGRESS);
+            let in_progress = err.raw_os_error() == Some(libc::EINPROGRESS);
             #[cfg(windows)]
             let in_progress = err.kind() == io::ErrorKind::WouldBlock;
 
@@ -1006,7 +1006,7 @@ impl Async<UnixStream> {
         socket
             .connect(&socket2::SockAddr::unix(path)?)
             .or_else(|err| {
-                if err.raw_os_error() == Some(crate::sys::libc::EINPROGRESS) {
+                if err.raw_os_error() == Some(libc::EINPROGRESS) {
                     Ok(())
                 } else {
                     Err(err)

--- a/src/io_event.rs
+++ b/src/io_event.rs
@@ -114,7 +114,7 @@ fn notifier() -> io::Result<(Socket, Socket)> {
 #[cfg(target_os = "linux")]
 mod linux {
     use super::*;
-    use nix::sys::eventfd::{eventfd, EfdFlags};
+    use crate::sys::linux::{self, eventfd, EfdFlags};
     use std::os::unix::io::AsRawFd;
 
     pub(crate) struct EventFd(std::os::unix::io::RawFd);
@@ -126,7 +126,7 @@ mod linux {
         }
 
         pub fn try_clone(&self) -> Result<EventFd, io::Error> {
-            nix::unistd::dup(self.0).map(EventFd).map_err(io_err)
+            linux::unistd::dup(self.0).map(EventFd).map_err(io_err)
         }
     }
 
@@ -138,13 +138,13 @@ mod linux {
 
     impl Drop for EventFd {
         fn drop(&mut self) {
-            let _ = nix::unistd::close(self.0);
+            let _ = linux::unistd::close(self.0);
         }
     }
 
-    fn io_err(err: nix::Error) -> io::Error {
+    fn io_err(err: linux::Error) -> io::Error {
         match err {
-            nix::Error::Sys(code) => code.into(),
+            linux::Error::Sys(code) => code.into(),
             err => io::Error::new(io::ErrorKind::Other, Box::new(err)),
         }
     }
@@ -152,14 +152,14 @@ mod linux {
     impl Read for &EventFd {
         #[inline]
         fn read(&mut self, buf: &mut [u8]) -> std::result::Result<usize, std::io::Error> {
-            nix::unistd::read(self.0, buf).map_err(io_err)
+            linux::unistd::read(self.0, buf).map_err(io_err)
         }
     }
 
     impl Write for &EventFd {
         #[inline]
         fn write(&mut self, buf: &[u8]) -> std::result::Result<usize, std::io::Error> {
-            nix::unistd::write(self.0, buf).map_err(io_err)
+            linux::unistd::write(self.0, buf).map_err(io_err)
         }
 
         #[inline]

--- a/src/io_event.rs
+++ b/src/io_event.rs
@@ -127,7 +127,7 @@ mod linux {
         }
 
         pub fn try_clone(&self) -> Result<EventFd, io::Error> {
-            unistd::dup(self.0).map(EventFd).map_err(io_err)
+            unistd::dup(self.0).map(EventFd)
         }
     }
 
@@ -153,14 +153,14 @@ mod linux {
     impl Read for &EventFd {
         #[inline]
         fn read(&mut self, buf: &mut [u8]) -> std::result::Result<usize, std::io::Error> {
-            unistd::read(self.0, buf).map_err(io_err)
+            unistd::read(self.0, buf)
         }
     }
 
     impl Write for &EventFd {
         #[inline]
         fn write(&mut self, buf: &[u8]) -> std::result::Result<usize, std::io::Error> {
-            unistd::write(self.0, buf).map_err(io_err)
+            unistd::write(self.0, buf)
         }
 
         #[inline]

--- a/src/io_event.rs
+++ b/src/io_event.rs
@@ -114,7 +114,7 @@ fn notifier() -> io::Result<(Socket, Socket)> {
 #[cfg(target_os = "linux")]
 mod linux {
     use super::*;
-    use crate::sys::eventfd::{eventfd, EfdFlags};
+    use crate::sys::eventfd::eventfd;
     use crate::sys::unistd;
     use std::os::unix::io::AsRawFd;
 
@@ -122,7 +122,7 @@ mod linux {
 
     impl EventFd {
         pub fn new() -> Result<Self, std::io::Error> {
-            let fd = eventfd(0, EfdFlags::EFD_CLOEXEC | EfdFlags::EFD_NONBLOCK).map_err(io_err)?;
+            let fd = eventfd(0, libc::EFD_CLOEXEC | libc::EFD_NONBLOCK)?;
             Ok(EventFd(fd))
         }
 
@@ -140,13 +140,6 @@ mod linux {
     impl Drop for EventFd {
         fn drop(&mut self) {
             let _ = unistd::close(self.0);
-        }
-    }
-
-    fn io_err(err: crate::sys::Error) -> io::Error {
-        match err {
-            crate::sys::Error::Sys(code) => code.into(),
-            err => io::Error::new(io::ErrorKind::Other, Box::new(err)),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@ mod context;
 mod io_event;
 mod reactor;
 mod run;
+mod sys;
 mod task;
 mod thread_local;
 mod throttle;

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -32,12 +32,13 @@ use std::time::{Duration, Instant};
 
 use crossbeam_queue::ArrayQueue;
 use futures_util::future;
-#[cfg(unix)]
-use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use once_cell::sync::Lazy;
 use slab::Slab;
 #[cfg(windows)]
 use socket2::Socket;
+
+#[cfg(unix)]
+use crate::sys::fcntl::{fcntl, FcntlArg, OFlag};
 
 use crate::io_event::IoEvent;
 
@@ -446,7 +447,7 @@ mod sys {
     use std::os::unix::io::RawFd;
     use std::time::Duration;
 
-    use nix::sys::epoll::{
+    use crate::sys::epoll::{
         epoll_create1, epoll_ctl, epoll_wait, EpollCreateFlags, EpollEvent, EpollFlags, EpollOp,
     };
 
@@ -537,10 +538,10 @@ mod sys {
     use std::os::unix::io::RawFd;
     use std::time::Duration;
 
-    use nix::errno::Errno;
-    use nix::fcntl::{fcntl, FcntlArg, FdFlag};
-    use nix::libc;
-    use nix::sys::event::{kevent_ts, kqueue, EventFilter, EventFlag, FilterFlag, KEvent};
+    use crate::sys::errno::Errno;
+    use crate::sys::event::{kevent_ts, kqueue, EventFilter, EventFlag, FilterFlag, KEvent};
+    use crate::sys::fcntl::{fcntl, FcntlArg, FdFlag};
+    use crate::sys::libc;
 
     use super::io_err;
 

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -642,7 +642,7 @@ mod sys {
             Ok(Reactor(Epoll::new()?))
         }
         pub fn register(&self, sock: RawSocket, key: usize) -> io::Result<()> {
-            self.0.register(&As(sock), 0, key as u64)
+            self.0.register(&As(sock), EventFlag::empty(), key as u64)
         }
         pub fn reregister(
             &self,
@@ -651,7 +651,7 @@ mod sys {
             read: bool,
             write: bool,
         ) -> io::Result<()> {
-            let mut flags = libc::ONESHOT;
+            let mut flags = EventFlag::ONESHOT;
             if read {
                 flags |= read_flags();
             }
@@ -682,10 +682,10 @@ mod sys {
         }
     }
     fn read_flags() -> EventFlag {
-        libc::IN | libc::RDHUP
+        EventFlag::IN | EventFlag::RDHUP
     }
     fn write_flags() -> EventFlag {
-        libc::OUT
+        EventFlag::OUT
     }
 
     pub struct Events(wepoll_binding::Events);

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,0 +1,49 @@
+#[cfg(target_os = "linux")]
+pub mod linux {
+    pub use nix::sys::eventfd::{eventfd, EfdFlags};
+
+    pub mod unistd {
+        pub use nix::unistd::{close, dup, read, write};
+    }
+
+    pub use nix::Error;
+}
+
+#[cfg(unix)]
+pub mod fcntl {
+    pub use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "dragonfly",
+))]
+pub mod event {
+    pub use nix::sys::event::{kevent_ts, kqueue, EventFilter, EventFlag, FilterFlag, KEvent};
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "dragonfly",
+))]
+pub mod errno {
+    pub use nix::errno::Errno;
+}
+
+#[cfg(unix)]
+pub use nix::libc;
+
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "illumos"))]
+pub mod epoll {
+    pub use nix::sys::epoll::{
+        epoll_create1, epoll_ctl, epoll_wait, EpollCreateFlags, EpollEvent, EpollFlags, EpollOp,
+    };
+}

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -13,7 +13,42 @@ pub use nix::Error;
 
 #[cfg(unix)]
 pub mod fcntl {
-    pub use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
+    use super::check_err;
+    use std::os::unix::io::RawFd;
+
+    pub type OFlag = libc::c_int;
+    pub type FdFlag = libc::c_int;
+
+    #[allow(non_camel_case_types)]
+    #[allow(dead_code)]
+    /// Arguments passed to `fcntl`.
+    pub enum FcntlArg {
+        F_GETFL,
+        F_SETFL(OFlag),
+        F_SETFD(FdFlag),
+    }
+
+    /// Thin wrapper around `libc::fcntl`.
+    ///
+    /// See [`fcntl(2)`](http://man7.org/linux/man-pages/man2/fcntl.2.html) for details.
+    pub fn fcntl(fd: RawFd, arg: FcntlArg) -> Result<libc::c_int, std::io::Error> {
+        let res = unsafe {
+            match arg {
+                FcntlArg::F_GETFL => libc::fcntl(fd, libc::F_GETFL),
+                FcntlArg::F_SETFL(flag) => libc::fcntl(fd, libc::F_SETFL, flag),
+                FcntlArg::F_SETFD(flag) => libc::fcntl(fd, libc::F_SETFD, flag),
+            }
+        };
+        check_err(res)
+    }
+}
+
+fn check_err(res: libc::c_int) -> Result<libc::c_int, std::io::Error> {
+    if res == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    Ok(res)
 }
 
 #[cfg(any(
@@ -24,26 +59,16 @@ pub mod fcntl {
     target_os = "openbsd",
     target_os = "dragonfly",
 ))]
+/// Kqueue.
 pub mod event {
     pub use nix::sys::event::{kevent_ts, kqueue, EventFilter, EventFlag, FilterFlag, KEvent};
 }
 
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "dragonfly",
-))]
-pub mod errno {
-    pub use nix::errno::Errno;
-}
-
 #[cfg(unix)]
-pub use nix::libc;
+pub use libc;
 
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "illumos"))]
+/// Epoll.
 pub mod epoll {
     pub use nix::sys::epoll::{
         epoll_create1, epoll_ctl, epoll_wait, EpollCreateFlags, EpollEvent, EpollFlags, EpollOp,

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -85,6 +85,7 @@ pub mod fcntl {
     }
 }
 
+#[cfg(unix)]
 fn check_err(res: libc::c_int) -> Result<libc::c_int, std::io::Error> {
     if res == -1 {
         return Err(std::io::Error::last_os_error());

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,6 +1,15 @@
 #[cfg(target_os = "linux")]
 pub mod eventfd {
-    pub use nix::sys::eventfd::{eventfd, EfdFlags};
+    use super::check_err;
+    use std::os::unix::io::RawFd;
+
+    pub type EfdFlags = libc::c_int;
+
+    pub fn eventfd(initval: libc::c_uint, flags: EfdFlags) -> Result<RawFd, std::io::Error> {
+        let res = unsafe { libc::eventfd(initval, flags) };
+
+        check_err(res).map(|r| r as RawFd)
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,13 +1,15 @@
 #[cfg(target_os = "linux")]
-pub mod linux {
+pub mod eventfd {
     pub use nix::sys::eventfd::{eventfd, EfdFlags};
-
-    pub mod unistd {
-        pub use nix::unistd::{close, dup, read, write};
-    }
-
-    pub use nix::Error;
 }
+
+#[cfg(target_os = "linux")]
+pub mod unistd {
+    pub use nix::unistd::{close, dup, read, write};
+}
+
+#[cfg(target_os = "linux")]
+pub use nix::Error;
 
 #[cfg(unix)]
 pub mod fcntl {


### PR DESCRIPTION
Using `nix` is currently a major regression for async-std, as this makes it not link on android (both new and older apis) as well as ios.