### PR TITLE
More robust I/O and tests

### DIFF
--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -551,7 +551,8 @@ mod sys {
                 KEvent::new(fd as _, EventFilter::EVFILT_WRITE, flags, FFLAGS, 0, udata),
             ];
             let mut eventlist = changelist;
-            kevent_ts(self.0, &changelist, &mut eventlist, None).map_err(io_err)
+            kevent_ts(self.0, &changelist, &mut eventlist, None).map_err(io_err)?;
+            Ok(())
         }
         pub fn reregister(
             &self,

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -543,8 +543,8 @@ mod sys {
             fcntl(fd, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)).map_err(io_err)?;
             Ok(Reactor(fd))
         }
-        pub fn register(&self, _fd: RawFd, _key: usize) -> io::Result<()> {
-            let flags = EventFlag::ADD | EventFlag::EV_CLEAR;
+        pub fn register(&self, fd: RawFd, key: usize) -> io::Result<()> {
+            let flags = EventFlag::EV_ADD | EventFlag::EV_CLEAR;
             let udata = key as _;
             let changelist = [
                 KEvent::new(fd as _, EventFilter::EVFILT_READ, flags, FFLAGS, 0, udata),
@@ -553,7 +553,13 @@ mod sys {
             let mut eventlist = changelist;
             kevent_ts(self.0, &changelist, &mut eventlist, None).map_err(io_err)
         }
-        pub fn reregister(&self, fd: RawFd, key: usize, read: bool, write: bool) -> io::Result<()> {
+        pub fn reregister(
+            &self,
+            _fd: RawFd,
+            _key: usize,
+            _read: bool,
+            _write: bool,
+        ) -> io::Result<()> {
             Ok(())
         }
         pub fn deregister(&self, fd: RawFd) -> io::Result<()> {

--- a/tests/async_io.rs
+++ b/tests/async_io.rs
@@ -85,13 +85,13 @@ fn tcp_reader_hangup() -> io::Result<()> {
         let mut stream2 = Async::<TcpStream>::connect(&addr).await?;
         let stream1 = task.await?.0;
 
-        Task::local(async move {
+        let task = Task::local(async move {
             Timer::after(Duration::from_secs(1)).await;
             drop(stream1);
-        })
-        .detach();
+        });
 
         while stream2.write_all(LOREM_IPSUM).await.is_ok() {}
+        task.await;
 
         Ok(())
     })
@@ -107,16 +107,16 @@ fn tcp_writer_hangup() -> io::Result<()> {
         let mut stream2 = Async::<TcpStream>::connect(&addr).await?;
         let stream1 = task.await?.0;
 
-        Task::local(async move {
+        let task = Task::local(async move {
             Timer::after(Duration::from_secs(1)).await;
             drop(stream1);
-        })
-        .detach();
+        });
 
         let mut v = vec![];
         stream2.read_to_end(&mut v).await?;
         assert!(v.is_empty());
 
+        task.await;
         Ok(())
     })
 }
@@ -243,13 +243,13 @@ fn uds_reader_hangup() -> io::Result<()> {
     run(async {
         let (socket1, mut socket2) = Async::<UnixStream>::pair()?;
 
-        Task::local(async move {
+        let task = Task::local(async move {
             Timer::after(Duration::from_secs(1)).await;
             drop(socket1);
-        })
-        .detach();
+        });
 
         while socket2.write_all(LOREM_IPSUM).await.is_ok() {}
+        task.await;
 
         Ok(())
     })
@@ -261,16 +261,16 @@ fn uds_writer_hangup() -> io::Result<()> {
     run(async {
         let (socket1, mut socket2) = Async::<UnixStream>::pair()?;
 
-        Task::local(async move {
+        let task = Task::local(async move {
             Timer::after(Duration::from_secs(1)).await;
             drop(socket1);
-        })
-        .detach();
+        });
 
         let mut v = vec![];
         socket2.read_to_end(&mut v).await?;
         assert!(v.is_empty());
 
+        task.await;
         Ok(())
     })
 }


### PR DESCRIPTION
- Handle EPOLLHUP and EPOLLERR
- Treat EVFILT_READ with EV_EOF as a write event.
- Add that cover the scenario in #131 

kqueue is now again used in edge-triggered mode. I modeled it after Go's kqueue bindings.

Closes #131 
cc @sopium 