### PR TITLE
Depend on individual crossbeam crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ tokio02 = ["tokio"]
 
 [dependencies]
 async-task = "3.0.0"
-crossbeam = "0.7.3"
+crossbeam-deque = "0.7.3"
+crossbeam-queue = "0.2.1"
+crossbeam-utils = "0.7.2"
 futures-util = { version = "0.3.5", default-features = false, features = ["std", "io"] }
 futures-io = { version = "0.3.5", default-features = false, features = ["std"] }
 once_cell = "1.3.1"

--- a/src/block_on.rs
+++ b/src/block_on.rs
@@ -11,7 +11,7 @@ use std::cell::RefCell;
 use std::future::Future;
 use std::task::{Context, Poll, Waker};
 
-use crossbeam::sync::Parker;
+use crossbeam_utils::sync::Parker;
 
 use crate::context;
 

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use std::task::{Poll, Waker};
 use std::time::{Duration, Instant};
 
-use crossbeam::queue::ArrayQueue;
+use crossbeam_queue::ArrayQueue;
 use futures_util::future;
 #[cfg(unix)]
 use nix::fcntl::{fcntl, FcntlArg, OFlag};

--- a/src/thread_local.rs
+++ b/src/thread_local.rs
@@ -10,7 +10,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::thread::{self, ThreadId};
 
-use crossbeam::queue::SegQueue;
+use crossbeam_queue::SegQueue;
 use scoped_tls_hkt::scoped_thread_local;
 
 use crate::io_event::IoEvent;

--- a/src/work_stealing.rs
+++ b/src/work_stealing.rs
@@ -23,8 +23,8 @@ use std::future::Future;
 use std::num::Wrapping;
 use std::panic;
 
-use crossbeam::deque;
-use crossbeam::sync::ShardedLock;
+use crossbeam_deque as deque;
+use crossbeam_utils::sync::ShardedLock;
 use once_cell::sync::Lazy;
 use scoped_tls_hkt::scoped_thread_local;
 use slab::Slab;


### PR DESCRIPTION
This shrinks the dependency graph slightly, as it no longer pulls in the
unused crossbeam-channel crate.