### PR TITLE
add new async functions readable() and writable() for Async

### DIFF
--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -159,6 +159,7 @@ impl<T: IntoRawFd> IntoRawFd for Async<T> {
         self.into_inner().unwrap().into_raw_fd()
     }
 }
+
 #[cfg(windows)]
 impl<T: AsRawSocket> Async<T> {
     /// Creates an async I/O handle.
@@ -453,6 +454,54 @@ impl<T> Async<T> {
             }
             self.source.writable().await?;
         }
+    }
+
+    /// Wait until the async I/O handle is readable.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use smol::Async;
+    /// use std::net::{TcpListener, TcpStream};
+    /// use futures_util::io::AsyncWriteExt;
+    ///
+    /// # smol::run(async {
+    /// let listener = Async::<TcpListener>::bind("0.0.0.0:0")?;
+    /// let addr = listener.get_ref().local_addr()?;
+    ///
+    /// let mut stream1 = Async::<TcpStream>::connect(addr).await?;
+    /// let (stream2, _) = listener.accept().await?;
+    ///
+    /// stream1.write(b"test").await?;
+    /// stream2.readable().await?;
+    ///
+    /// # std::io::Result::Ok(()) });
+    /// ```
+    #[inline]
+    pub async fn readable(&self) -> io::Result<()> {
+        self.source.readable().await
+    }
+
+    /// Wait until the async I/O handle is writable.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use smol::Async;
+    /// use std::net::{TcpListener, TcpStream};
+    ///
+    /// # smol::run(async {
+    /// let listener = Async::<TcpListener>::bind("0.0.0.0:0")?;
+    /// let addr = listener.get_ref().local_addr()?;
+    ///
+    /// let stream = Async::<TcpStream>::connect(addr).await?;
+    ///
+    /// stream.writable().await?;
+    /// # std::io::Result::Ok(()) });
+    /// ```
+    #[inline]
+    pub async fn writable(&self) -> io::Result<()> {
+        self.source.writable().await
     }
 }
 

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -191,7 +191,7 @@ impl<T: AsRawSocket> Async<T> {
     /// use std::net::TcpListener;
     ///
     /// # smol::run(async {
-    /// let listener = TcpListener::bind("127.0.0.1:80")?;
+    /// let listener = TcpListener::bind("0.0.0.0:0")?;
     /// let listener = Async::new(listener)?;
     /// # std::io::Result::Ok(()) });
     /// ```
@@ -232,7 +232,7 @@ impl<T> Async<T> {
     /// use std::net::TcpListener;
     ///
     /// # smol::run(async {
-    /// let listener = Async::<TcpListener>::bind("127.0.0.1:80")?;
+    /// let listener = Async::<TcpListener>::bind("0.0.0.0:0")?;
     /// let inner = listener.get_ref();
     /// # std::io::Result::Ok(()) });
     /// ```
@@ -249,7 +249,7 @@ impl<T> Async<T> {
     /// use std::net::TcpListener;
     ///
     /// # smol::run(async {
-    /// let mut listener = Async::<TcpListener>::bind("127.0.0.1:80")?;
+    /// let mut listener = Async::<TcpListener>::bind("0.0.0.0:0")?;
     /// let inner = listener.get_mut();
     /// # std::io::Result::Ok(()) });
     /// ```
@@ -266,7 +266,7 @@ impl<T> Async<T> {
     /// use std::net::TcpListener;
     ///
     /// # smol::run(async {
-    /// let listener = Async::<TcpListener>::bind("127.0.0.1:80")?;
+    /// let listener = Async::<TcpListener>::bind("0.0.0.0:0")?;
     /// let inner = listener.into_inner()?;
     /// # std::io::Result::Ok(()) });
     /// ```


### PR DESCRIPTION
add tow async functions `readable()` and `writable` for `Async<T>`

- `readable()` this method allows users to wait until the `Async<T>` is readable.
- `writable()` this method allows users to wait until the `Async<T>` is writable.

this PR should solve the problem in #139 