### PR TITLE
Add 'include' directive in Cargo.toml to reduce package size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ async-io = "0.1.3"
 multitask = "0.2.0"
 num_cpus = "1.13.0"
 once_cell = "1.4.0"
-blocking = "0.4.7"
 
 [dependencies.tokio]
 version = "0.2.21"
@@ -45,6 +44,7 @@ async-native-tls = "0.3.3"
 async-std = "1.6.2"
 async-tungstenite = { version = "0.7.1", features = ["async-native-tls"] }
 base64 = "0.12.3"
+blocking = "0.4.7"
 ctrlc = "3.1.5"
 futures = "0.3.5"
 futures-lite = "0.1.5"


### PR DESCRIPTION
This will exclude files that are not required to build the code, saving (only) 4kb in the crate archive.

<img width="487" alt="Screenshot 2020-05-26 at 20 55 32" src="https://user-images.githubusercontent.com/63622/82903239-41baee00-9f93-11ea-8b64-5c2a4099e69b.png">

Please feel free to close this issue, after all, it doesn't make much of a difference right now at least.
