### PR TITLE
Add Timer::{reset_at, reset_after}

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -106,6 +106,22 @@ impl Timer {
         let id = None;
         Timer { id, when }
     }
+
+    /// Reset the timer to fire at the specified instant.
+    pub fn reset_at(&mut self, when: Instant) {
+        match self.id {
+            None => {}
+            Some(id) => {
+                Reactor::get().reset_timer(self.when, id, when);
+                self.when = when;
+            }
+        }
+    }
+
+    /// Reset timer to fire after the specified duration of time.
+    pub fn reset_after(&mut self, dur: Duration) {
+        self.reset_at(Instant::now() + dur);
+    }
 }
 
 impl Drop for Timer {

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -1,4 +1,6 @@
+use futures::prelude::*;
 use smol::{self, Timer};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 #[test]
@@ -22,4 +24,28 @@ fn timer_after() {
     });
 
     assert!(before.elapsed() >= Duration::from_secs(1));
+}
+
+#[test]
+fn timer_reset() {
+    smol::run(async move {
+        let start = Instant::now();
+        let t = Arc::new(Mutex::new(Timer::after(Duration::from_secs(10))));
+        let t1 = t.clone();
+        // Use another thread instead of smol::Task to avoid any interference
+        // with the runtime.
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(500));
+            t1.lock().unwrap().reset_after(Duration::from_secs(1));
+        });
+        smol::Task::local(futures::future::poll_fn(move |cx| {
+            t.lock().unwrap().poll_unpin(cx)
+        }))
+        .await;
+
+        let e = start.elapsed();
+
+        assert!(e >= Duration::from_millis(1300));
+        assert!(e < Duration::from_millis(1700));
+    });
 }


### PR DESCRIPTION
This is very useful for handling e.g. timeouts. Tokio, futures-timer or timerfd all have similar methods. The implementation is pretty straightforward.