### PR TITLE
set minimum tokio version to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ slab = "0.4.2"
 socket2 = { version = "0.3.12", features = ["pair", "unix"] }
 
 [dependencies.tokio]
-version = "0.2.19"
+version = "0.2"
 default-features = false
 features = ["rt-threaded"]
 optional = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -34,7 +34,7 @@ signal-hook = "0.1.13"
 smol = { path = "../", features = ["tokio02"] }
 surf = { version = "2.0.0-alpha.1", default-features = false, features = ["h1-client"] }
 tempfile = "3.1.0"
-tokio = { version = "0.2.18", default-features = false }
+tokio = { version = "0.2", default-features = false }
 tungstenite = "0.10.1"
 url = "2.1.1"
 


### PR DESCRIPTION
This patch lowers the minimum required Tokio version to `0.2.13`. A project I'm working on had trouble when upgrading to more recent Tokio versions and had to pin to `tokio@0.2.13` to prevent regressions. This patch allows us to use `async-std` with the `smol` backend and gradually build out more runtime-agnostic components. Thanks!

__edit:__ I locally verified that pinning `tokio` to `0.2.13` works with `smol`'s `tokio02` feature flag. This shouldn't affect any existing users of `smol` and should strictly enable more applications to work.