### PR TITLE
Ensure timers wake the last waker that polled them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ winapi = { version = "0.3.8", features = ["ioapiset"] }
 
 [dev-dependencies]
 criterion = "0.3.2"
-futures = { version = "0.3.5", default-features = false, features = ["std"] }
+futures = { version = "0.3.5", default-features = false, features = ["std", "async-await"] }
 num_cpus = "1.13.0"
 piper = "0.1.3"
 tempfile = "3.1.0"

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -1,5 +1,8 @@
-use smol::{self, Timer};
 use std::time::{Duration, Instant};
+
+use futures::channel::oneshot;
+use futures::poll;
+use smol::{self, Task, Timer};
 
 #[test]
 fn timer_at() {
@@ -18,6 +21,31 @@ fn timer_after() {
     let before = smol::run(async {
         let now = Instant::now();
         Timer::after(Duration::from_secs(1)).await;
+        now
+    });
+
+    assert!(before.elapsed() >= Duration::from_secs(1));
+}
+
+#[test]
+fn timer_across_tasks() {
+    let before = smol::run(async {
+        let now = Instant::now();
+        let (sender, receiver) = oneshot::channel();
+
+        let task1 = Task::spawn(async move {
+            let mut timer = Timer::after(Duration::from_secs(1));
+            assert!(poll!(&mut timer).is_pending());
+            sender.send(timer).unwrap();
+        });
+
+        let task2 = Task::spawn(async move {
+            let timer = receiver.await.unwrap();
+            timer.await;
+        });
+
+        task1.detach();
+        task2.await;
         now
     });
 


### PR DESCRIPTION
The following test case hangs indefinitely on `master`:

https://github.com/spinda/smol/blob/9109bd4f6a75868979f63835d05d3530744827dc/tests/timer.rs#L30-L53

`Timer` only calls `Reactor::insert_timer` on the first call to `poll`. This means that only the first task to poll the `Timer` gets woken up when the timer completes. If the `Timer` is, say, sent to another task which then `await`s on it, that task will wait indefinitely.