### PR TITLE
Change piper to async-channel on web-crawler example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0.28"
 async-h1 = "1.1.2"
 async-native-tls = "0.3.3"
 async-std = "1.5.0"
+async-channel = "1.1.1"
 async-tungstenite = { version = "0.4.2", features = ["async-native-tls"] }
 base64 = "0.12.0"
 ctrlc = "3.1.4"

--- a/examples/web-crawler.rs
+++ b/examples/web-crawler.rs
@@ -17,11 +17,10 @@ use smol::Task;
 const ROOT: &str = "https://www.rust-lang.org";
 
 /// Fetches the HTML contents of a web page.
-async fn fetch(url: String, sender: Sender<String>) -> Result<()> {
+async fn fetch(url: String, sender: Sender<String>) {
     let body = surf::get(&url).recv_string().await;
     let body = body.unwrap_or_default();
-    sender.send(body).await?;
-    Ok(())
+    sender.send(body).await.unwrap();
 }
 
 /// Extracts links from a HTML body.
@@ -55,7 +54,7 @@ fn main() -> Result<()> {
                     Some(url) => {
                         println!("{}", url);
                         tasks += 1;
-                        Task::spawn(fetch(url, s.clone())).unwrap().detach();
+                        Task::spawn(fetch(url, s.clone())).detach();
                     }
                 }
             }


### PR DESCRIPTION
- `piper` is deprecated so the crate need to be changed to `async-channel`