### PR TITLE
Add doc-comment to test README examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ async-std = "1.6.2"
 async-tungstenite = { version = "0.7.1", features = ["async-native-tls"] }
 base64 = "0.12.3"
 ctrlc = "3.1.5"
+doc-comment = "0.3"
 futures = "0.3.5"
 http = "0.2.1"
 http-types = "2.3.0"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A small and fast async runtime.
 
 Connect to an HTTP website, make a GET request, and pipe the response to the standard output:
 
-```rust
+```rust,no_run
 use async_net::TcpStream;
 use smol::{io, prelude::*, Unblock};
 
@@ -75,7 +75,7 @@ The certificate file was generated using
 [minica](https://github.com/jsha/minica) and
 [openssl](https://www.openssl.org/):
 
-```
+```text
 minica --domains localhost -ip-addresses 127.0.0.1 -ca-cert certificate.pem
 openssl pkcs12 -export -out identity.pfx -inkey localhost/key.pem -in localhost/cert.pem
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
+#[cfg(doctest)]
+doc_comment::doctest!("../README.md");
+
 use std::env;
 use std::future::Future;
 


### PR DESCRIPTION
This PR adds a dev dependency in order to check the README file examples.