### PR TITLE
allow spawning more global executor threads

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,9 +79,11 @@ pub mod prelude {
 
 /// Spawns a task onto the single-threaded global executor.
 ///
-/// There is a single-threaded global executor that gets lazily initialized on first use. It is
-/// advisable to use it in tests or small programs, but it is otherwise a better idea to define
+/// There is a (single-threaded by default) global executor that gets lazily initialized on first use.
+/// It is advisable to use it in tests or small programs, but it is otherwise a better idea to define
 /// your own [`Executor`]s.
+/// You can configure the number of threads of the global executor using the `SMOL_THREADS` environment
+/// variable.
 ///
 /// # Examples
 ///
@@ -96,15 +98,22 @@ pub mod prelude {
 /// ```
 pub fn spawn<T: Send + 'static>(future: impl Future<Output = T> + Send + 'static) -> Task<T> {
     static GLOBAL: Lazy<Executor> = Lazy::new(|| {
-        thread::Builder::new()
-            .name("smol".to_string())
-            .spawn(|| {
-                loop {
+        let num_threads = {
+            // Parse SMOL_THREADS or run a monothreaded executor.
+            std::env::var("SMOL_THREADS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(1)
+        };
+        for n in 1..=num_threads {
+            thread::Builder::new()
+                .name(format!("smol-{}", n))
+                .spawn(|| loop {
                     let _ =
                         catch_unwind(|| async_io::block_on(GLOBAL.run(future::pending::<()>())));
-                }
-            })
-            .unwrap();
+                })
+                .expect("cannot spawn executor thread");
+        }
         Executor::new()
     });
     GLOBAL.spawn(future)


### PR DESCRIPTION
With smol 0.4, there is now a global executor which somehow works around the fact that smol 0.3 required you to be inside an executor to spawn more tasks on it.
Having it be single-threaded by default is imo better than automatically spawning num_cpus threads, a,d I fully understand that if the user wants to do more complicated things, they should run their own executor to their liking.
Allowing to "transform" the default single threaded executor into a multi threaded one seems trivial enough to do to be acceptable though, so here we are.